### PR TITLE
feat: support symlink file detect

### DIFF
--- a/lib/reader/harvester/harvester.go
+++ b/lib/reader/harvester/harvester.go
@@ -62,7 +62,7 @@ func readOpen(path string) (*os.File, error) {
 func (h *Harvester) NewJsonFileReader(pattern string, showLineNumber bool) (reader.Reader, error) {
 	var r reader.Reader
 	var err error
-	if h.file == nil {
+	if h == nil || h.file == nil {
 		return nil, fmt.Errorf("file is nil")
 	}
 
@@ -102,7 +102,7 @@ func (h *Harvester) NewLogFileReader(pattern string, showLineNumber bool) (reade
 	var r reader.Reader
 	var err error
 
-	if h.file == nil {
+	if h == nil || h.file == nil {
 		return nil, fmt.Errorf("file is nil")
 	}
 	encReaderMaxBytes := h.config.MaxBytes * 4

--- a/lib/reader/harvester/harvester.go
+++ b/lib/reader/harvester/harvester.go
@@ -15,6 +15,7 @@ import (
 	"infini.sh/agent/lib/reader/readfile"
 	"infini.sh/agent/lib/reader/readfile/encoding"
 	"infini.sh/agent/lib/reader/readjson"
+	"infini.sh/framework/core/errors"
 )
 
 type Harvester struct {
@@ -30,7 +31,7 @@ type Harvester struct {
 func NewHarvester(path string, offset int64) (*Harvester, error) {
 	f, err := readOpen(path)
 	if f == nil || err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to open file(%s),%v", path, err)
 	}
 	_, err = f.Seek(offset, io.SeekStart)
 	if err != nil {

--- a/lib/util/file.go
+++ b/lib/util/file.go
@@ -1,38 +1,3 @@
-// CountFileRows counts the number of rows in the specified file.
-// It takes a file path as an argument and returns the row count and an error if any.
-// If the file cannot be opened, it returns an error.
-//
-// Parameters:
-//   - filePath: The path to the file to be read.
-//
-// Returns:
-//   - int64: The number of rows in the file.
-//   - error: An error if the file cannot be opened or read.
-//
-// Example usage:
-//   count, err := CountFileRows("/path/to/file")
-//   if err != nil {
-//       log.Fatal(err)
-//   }
-//   fmt.Println("Number of rows:", count)
-
-// ResolveSymlink resolves the target file path of a symbolic link.
-// It takes a symbolic link path as an argument and returns the absolute path of the target file and an error if any.
-// If the symbolic link cannot be resolved, it returns an error.
-//
-// Parameters:
-//   - link: The path to the symbolic link.
-//
-// Returns:
-//   - string: The absolute path of the target file.
-//   - error: An error if the symbolic link cannot be resolved.
-//
-// Example usage:
-//   realPath, err := ResolveSymlink("/path/to/symlink")
-//   if err != nil {
-//       log.Fatal(err)
-//   }
-//   fmt.Println("Resolved path:", realPath)
 /* Copyright © INFINI Ltd. All rights reserved.
  * Web: https://infinilabs.com
  * Email: hello#infini.ltd */

--- a/lib/util/file.go
+++ b/lib/util/file.go
@@ -1,3 +1,38 @@
+// CountFileRows counts the number of rows in the specified file.
+// It takes a file path as an argument and returns the row count and an error if any.
+// If the file cannot be opened, it returns an error.
+//
+// Parameters:
+//   - filePath: The path to the file to be read.
+//
+// Returns:
+//   - int64: The number of rows in the file.
+//   - error: An error if the file cannot be opened or read.
+//
+// Example usage:
+//   count, err := CountFileRows("/path/to/file")
+//   if err != nil {
+//       log.Fatal(err)
+//   }
+//   fmt.Println("Number of rows:", count)
+
+// ResolveSymlink resolves the target file path of a symbolic link.
+// It takes a symbolic link path as an argument and returns the absolute path of the target file and an error if any.
+// If the symbolic link cannot be resolved, it returns an error.
+//
+// Parameters:
+//   - link: The path to the symbolic link.
+//
+// Returns:
+//   - string: The absolute path of the target file.
+//   - error: An error if the symbolic link cannot be resolved.
+//
+// Example usage:
+//   realPath, err := ResolveSymlink("/path/to/symlink")
+//   if err != nil {
+//       log.Fatal(err)
+//   }
+//   fmt.Println("Resolved path:", realPath)
 /* Copyright © INFINI Ltd. All rights reserved.
  * Web: https://infinilabs.com
  * Email: hello#infini.ltd */
@@ -7,9 +42,10 @@ package util
 import (
 	"bufio"
 	"os"
+	"path/filepath"
 )
 
-func CountFileRows(filePath string) (int64, error){
+func CountFileRows(filePath string) (int64, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return 0, err
@@ -22,4 +58,17 @@ func CountFileRows(filePath string) (int64, error){
 		count++
 	}
 	return count, nil
+}
+
+// ResolveSymlink Parse the target file path of the soft link
+func ResolveSymlink(link string) (string, error) {
+	realPath, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		return "", err
+	}
+	absPath, err := filepath.Abs(realPath)
+	if err != nil {
+		return "", err
+	}
+	return absPath, nil
 }


### PR DESCRIPTION
## What does this PR do
 support symlink file detect and fix symlink file nil check
## Rationale for this change
This pull request includes several enhancements and bug fixes in the `lib/reader/harvester/harvester.go`, `lib/util/file.go`, and `plugin/logs/file_detect.go` files. The changes focus on improving error handling, removing unused code, and adding new utility functions.

Error handling improvements:

* [`lib/reader/harvester/harvester.go`](diffhunk://#diff-9c683727e506a8bf19f13cdbb42f059c24cdf3fcc82e922fee3481242d451c97L33-R32): Added checks to ensure the file is not nil before proceeding with operations in the `NewHarvester`, `NewJsonFileReader`, and `NewLogFileReader` functions. [[1]](diffhunk://#diff-9c683727e506a8bf19f13cdbb42f059c24cdf3fcc82e922fee3481242d451c97L33-R32) [[2]](diffhunk://#diff-9c683727e506a8bf19f13cdbb42f059c24cdf3fcc82e922fee3481242d451c97R50-R52) [[3]](diffhunk://#diff-9c683727e506a8bf19f13cdbb42f059c24cdf3fcc82e922fee3481242d451c97R65-R67) [[4]](diffhunk://#diff-9c683727e506a8bf19f13cdbb42f059c24cdf3fcc82e922fee3481242d451c97R105-R107)

Code cleanup:

* [`lib/reader/harvester/harvester.go`](diffhunk://#diff-9c683727e506a8bf19f13cdbb42f059c24cdf3fcc82e922fee3481242d451c97L128-L137): Removed the unused `NewPlainTextRead` function.

New utility functions:

* [`lib/util/file.go`](diffhunk://#diff-7de217be2ab01be27987da2fc4dcfd72b17d7e720797d80be5224fcf123ea530R1-R35): Added `CountFileRows` and `ResolveSymlink` functions to count the number of rows in a file and resolve the target file path of a symbolic link, respectively. [[1]](diffhunk://#diff-7de217be2ab01be27987da2fc4dcfd72b17d7e720797d80be5224fcf123ea530R1-R35) [[2]](diffhunk://#diff-7de217be2ab01be27987da2fc4dcfd72b17d7e720797d80be5224fcf123ea530R45) [[3]](diffhunk://#diff-7de217be2ab01be27987da2fc4dcfd72b17d7e720797d80be5224fcf123ea530R62-R74)

Integration of new utility functions:

* [`plugin/logs/file_detect.go`](diffhunk://#diff-5180144365e492b347d3f826892b15fb8bab8f05bcf2ffa930787a90041442e4R13): Integrated the `ResolveSymlink` function to handle symbolic links in the `judgeEvent` method. [[1]](diffhunk://#diff-5180144365e492b347d3f826892b15fb8bab8f05bcf2ffa930787a90041442e4R13) [[2]](diffhunk://#diff-5180144365e492b347d3f826892b15fb8bab8f05bcf2ffa930787a90041442e4R83-R95)
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation