### PR TITLE
chore: commmit message check

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -12,7 +12,6 @@ jobs:
         with:
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
-          excludeTitle: 'true' # optional: this excludes the title of a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }}
           pattern: '^(change:|feat:|improve:|perf:|dep:|docs:|test:|ci:|style:|refactor:|fix:|fixdoc:|fixup:|merge|Merge|bumpver:|chore:|build:) .+$'
           flags: 'gm'

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,0 +1,36 @@
+name: 'commit-message-check'
+on:
+  pull_request:
+
+jobs:
+  check-commit-message:
+    name: check-subject
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-subject-type
+        uses: gsactions/commit-message-checker@v2
+        with:
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          pattern: '^(change:|feat:|improve:|perf:|dep:|docs:|test:|ci:|style:|refactor:|fix:|fixdoc:|fixup:|merge|Merge|bumpver:|chore:|build:) .+$'
+          flags: 'gm'
+          error: |
+            Subject line has to contain a commit type, e.g.: "chore: blabla" or a merge commit e.g.: "merge xxx".
+            Valid types are:
+              change        - API breaking change
+              feat          - API compatible new feature
+              improve       - Become better without functional changes
+              perf          - Performance improvement
+              dep           - dependency update
+              docs          - docs update
+              test          - test udpate
+              ci            - CI workflow update
+              refactor      - refactor without function change.
+              fix           - fix bug
+              fixdoc        - fix doc
+              fixup         - minor change: e.g., fix sth mentioned in a review.
+              bumpver       - Bump to a new version.
+              chore         - Nothing important.
+              build         - bot: dependabot.

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -13,7 +13,7 @@ jobs:
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^(change:|feat:|improve:|perf:|dep:|docs:|test:|ci:|style:|refactor:|fix:|fixdoc:|fixup:|merge|Merge|bumpver:|chore:|build:) .+$'
+          pattern: '^(change:|feat:|improve:|perf:|dep:|docs:|test:|ci:|style:|refactor:|fix:|fixdoc:|fixup:|merge|Merge|update|Update|bumpver:|chore:|build:) .+$'
           flags: 'gm'
           error: |
             Subject line has to contain a commit type, e.g.: "chore: blabla" or a merge commit e.g.: "merge xxx".


### PR DESCRIPTION
## What does this PR do
commmit message check
## Rationale for this change
This pull request introduces a new GitHub Actions workflow to ensure that commit messages follow a specific format. The workflow checks the commit messages for predefined types and patterns to maintain consistency and clarity in the commit history.

Key changes include:

* [`.github/workflows/commit-message-check.yml`](diffhunk://#diff-73e8619abf322bb25f592ba9554da3f8d577c5f9031cca8909560c3413d81a29R1-R36): Added a new workflow named `commit-message-check` that runs on pull requests. It uses the `gsactions/commit-message-checker` action to validate commit messages against a specified pattern. This ensures that commit messages include a valid type prefix such as `feat:`, `fix:`, `docs:`, etc.
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation