### PR TITLE
fix: actions permissions and upgrade osv to 1.9.1

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -16,14 +16,16 @@ on:
     branches: [ "main" ]
 
 permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
-  # Read commit contents
+  # Only need to read contents
   contents: read
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.9.1"
     with:
       # Example of specifying custom arguments
       scan-args: |-


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the GitHub Actions workflow configuration for the OSV scanner. The main changes involve updating permissions and the reusable workflow version.

Permissions update:

* [`.github/workflows/osv-scanner.yml`](diffhunk://#diff-cffe33bb0ffb2810cb2ba28b35e9fb9ebef98fd615b71ef50305846fa8ba0e00R19-R28): Added `actions: read` permission required to upload SARIF files to CodeQL, updated the comment for `contents: read` permission to clarify its necessity.

Workflow version update:

* [`.github/workflows/osv-scanner.yml`](diffhunk://#diff-cffe33bb0ffb2810cb2ba28b35e9fb9ebef98fd615b71ef50305846fa8ba0e00R19-R28): Changed the reusable workflow version from `1f1242919d8a60496dd1874b24b62b2370ed4c78` (v1.7.1) to `v1.9.1`.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation