### PR TITLE
chore: add logs and optimize some settings

### DIFF
--- a/generated_metrics_tasks.go
+++ b/generated_metrics_tasks.go
@@ -75,6 +75,8 @@ func generatedMetricsTasksConfig() error {
       CLUSTER_ID: "{{.cluster_id}}"
       CLUSTER_UUID: "{{.cluster_uuid}}"
       NODE_UUID: "{{.node_uuid}}"
+      CLUSTER_VERSION: "{{.cluster_version}}"
+      CLUSTER_DISTRIBUTION: "{{.cluster_distribution}}"
       CLUSTER_ENDPOINT: ["{{.cluster_endpoint}}"]
       CLUSTER_USERNAME: "{{.username}}"
       CLUSTER_PASSWORD: "{{.password}}"
@@ -89,13 +91,15 @@ func generatedMetricsTasksConfig() error {
 	}
 	var buf bytes.Buffer
 	err = tpl.Execute(&buf, map[string]interface{}{
-		"cluster_id":       clusterID,
-		"node_uuid":        nodeUUID,
-		"cluster_uuid":     clusterInfo.ClusterUUID,
-		"cluster_endpoint": endpoint,
-		"username":         username,
-		"password":         password,
-		"node_logs_path":   nodeLogsPath,
+		"cluster_id":           clusterID,
+		"node_uuid":            nodeUUID,
+		"cluster_version":      clusterInfo.Version.Number,
+		"cluster_distribution": clusterInfo.Version.Distribution,
+		"cluster_uuid":         clusterInfo.ClusterUUID,
+		"cluster_endpoint":     endpoint,
+		"username":             username,
+		"password":             password,
+		"node_logs_path":       nodeLogsPath,
 	})
 	if err != nil {
 		return fmt.Errorf("execute template error: %w", err)

--- a/lib/process/discover.go
+++ b/lib/process/discover.go
@@ -35,7 +35,8 @@ func DiscoverESProcessors(filter FilterFunc) (map[int]model.ProcessInfo, error) 
 	var resultProcesses = map[int]model.ProcessInfo{}
 	for _, p := range processes {
 		cmdline, err := p.Cmdline()
-		if err != nil {
+		if p == nil || err != nil {
+			log.Errorf("get process cmdline error: %v", err)
 			continue
 		}
 		if filter(cmdline) {
@@ -69,6 +70,7 @@ func DiscoverESProcessors(filter FilterFunc) (map[int]model.ProcessInfo, error) 
 
 			// If no listen addresses found, try to read from /proc/net/tcp and /proc/net/tcp6 files on linux
 			if len(addresses) == 0 && runtime.GOOS == "linux" {
+				log.Debugf("Try to read /proc/net/tcp and /proc/net/tcp6 files for process %d", p.Pid)
 				addresses = readProcTcpServicePorts(p)
 				addresses = append(addresses)
 			}

--- a/lib/process/elastic.go
+++ b/lib/process/elastic.go
@@ -5,6 +5,7 @@
 package process
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	log "github.com/cihub/seelog"
@@ -16,6 +17,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func DiscoverESNodeFromEndpoint(endpoint string, auth *model.BasicAuth) (*elastic.LocalNodeInfo, error) {
@@ -142,9 +144,13 @@ func tryGetESClusterInfo(addr model.ListenAddr) (string, *elastic.ClusterInforma
 		}
 
 		endpoint = fmt.Sprintf("%s://%s:%d", schema, ip, addr.Port)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
 		req := &util.Request{
-			Method: util.Verb_GET,
-			Url:    endpoint,
+			Method:  util.Verb_GET,
+			Url:     endpoint,
+			Context: ctx,
 		}
 		result, err := util.ExecuteRequest(req)
 		if err != nil {

--- a/lib/util/elastic.go
+++ b/lib/util/elastic.go
@@ -22,7 +22,7 @@ func GetLocalNodeInfo(endpoint string, auth *model.BasicAuth) (string, *elastic.
 	if auth != nil {
 		req.SetBasicAuth(auth.Username, auth.Password.Get())
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	req.Context = ctx
 	resp, err := util.ExecuteRequest(&req)


### PR DESCRIPTION
## What does this PR do
This pull request includes changes to enhance error handling, improve logging, and add new context management features. The most important changes include updates to the `generated_metrics_tasks.go` and `lib/process` files.

Enhancements to error handling and logging:

* [`lib/process/discover.go`](diffhunk://#diff-8dff64fcf8a4660559fe74e9c9242105f1580417b702c915c3cf5c6ad7cbf6adL38-R39): Improved error handling by adding a check for `nil` processes and logging errors when retrieving process command lines. Added debug logging for reading `/proc/net/tcp` and `/proc/net/tcp6` files on Linux. [[1]](diffhunk://#diff-8dff64fcf8a4660559fe74e9c9242105f1580417b702c915c3cf5c6ad7cbf6adL38-R39) [[2]](diffhunk://#diff-8dff64fcf8a4660559fe74e9c9242105f1580417b702c915c3cf5c6ad7cbf6adR73)

Context management improvements:

* [`lib/process/elastic.go`](diffhunk://#diff-4223feb7a735bddbef22b77c4e8656f1e3cb5a42b3610605ac2d226d6f73cb34R147-R153): Added context management with a timeout of 3 seconds for Elasticsearch cluster information retrieval.
* [`lib/util/elastic.go`](diffhunk://#diff-d0c1447ba0afc7a27bd71c9c750439d31d6706749fd894b8e4a37898d416d7adL25-R25): Updated context timeout from 1 second to 3 seconds for local node information retrieval.

New metrics configuration fields:

* [`generated_metrics_tasks.go`](diffhunk://#diff-5d91e773eac9e4d25a1896357b631b88504818d9759a8cc04aeac93f5cd42d59R78-R79): Added `CLUSTER_VERSION` and `CLUSTER_DISTRIBUTION` fields to the metrics tasks configuration. [[1]](diffhunk://#diff-5d91e773eac9e4d25a1896357b631b88504818d9759a8cc04aeac93f5cd42d59R78-R79) [[2]](diffhunk://#diff-5d91e773eac9e4d25a1896357b631b88504818d9759a8cc04aeac93f5cd42d59R96-R97)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation