### PR TITLE
chore: update release notes for v1.28.2

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -7,6 +7,15 @@ title: "Release Notes"
 
 Information about release notes of INFINI Agent is provided here.
 
+## 1.28.2 (2025-02-15)
+
+This release includes updates from the underlying [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Gateway itself, the improvements inherited from Framework benefit Gateway indirectly.
+
+### Improvements
+
+- Add logs and optimize some settings (#17)
+- Enroll failed on docker with diffent user process  (#11)
+
 ## 1.28.1 (2025-01-24)
 
 ### Improvements

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -7,6 +7,14 @@ title: "版本历史"
 
 这里是 INFINI Agent 历史版本发布的相关说明。
 
+## 1.28.2 (2025-02-15)
+
+### Improvements
+
+- Add logs and optimize some settings (#17)
+- Enroll failed on docker with diffent user process (#11)
+- 同步更新 [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/) 修复的一些已知问题
+
 ## 1.28.1 (2025-01-24)
 
 ### Improvements


### PR DESCRIPTION
## What does this PR do
This pull request updates the release notes for version 1.28.2 of INFINI Agent in both English and Chinese documentation. The most important changes include adding details about the improvements and updates from the underlying Framework v1.1.2.

Updates to release notes:

* [`docs/content.en/docs/release-notes/_index.md`](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5R10-R18): Added release notes for version 1.28.2, including improvements and updates from Framework v1.1.2.
* [`docs/content.zh/docs/release-notes/_index.md`](diffhunk://#diff-4ff3d025818365a9a33f0fbd7fd1853b95162421d6d7d8067fce7fb0e3f9349fR10-R17): Added release notes for version 1.28.2 in Chinese, including improvements and updates from Framework v1.1.2.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation