### PR TITLE
chore: typo to release note

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -9,7 +9,7 @@ Information about release notes of INFINI Agent is provided here.
 
 ## 1.28.2 (2025-02-15)
 
-This release includes updates from the underlying [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Gateway itself, the improvements inherited from Framework benefit Gateway indirectly.
+This release includes updates from the underlying [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.
 
 ### Improvements
 


### PR DESCRIPTION
## What does this PR do
This pull request includes a minor change to the release notes for INFINI Agent. The change corrects a reference from "Gateway" to "Agent" to accurately reflect the component that benefits from the underlying framework updates.

Documentation update:

* [`docs/content.en/docs/release-notes/_index.md`](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5L12-R12): Corrected the reference from "Gateway" to "Agent" to accurately describe the component benefiting from the framework updates.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation