### PR TITLE
chore: add metrics enable to the main config

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -49,6 +49,9 @@ api:
 
 agent:
 
+metrics:
+  enabled: true
+
 configs:
   #for managed client's setting
   managed: true # managed by remote servers

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -7,6 +7,17 @@ title: "Release Notes"
 
 Information about release notes of INFINI Agent is provided here.
 
+## Latest (In development)
+
+### Breaking changes
+
+### Features
+
+### Bug fix
+
+### Improvements
+- Add metrics enable to the main config (#23)
+
 ## 1.28.2 (2025-02-15)
 
 This release includes updates from the underlying [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Gateway itself, the improvements inherited from Framework benefit Gateway indirectly.

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -18,7 +18,7 @@ Information about release notes of INFINI Agent is provided here.
 
 ### Improvements
 - Add metrics enable to the main config (#23)
-- 
+
 ## 1.28.2 (2025-02-15)
 
 This release includes updates from the underlying [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -7,30 +7,18 @@ title: "Release Notes"
 
 Information about release notes of INFINI Agent is provided here.
 
-<<<<<<< HEAD
 ## Latest (In development)
 
 ### Breaking changes
 
 ### Features
+- Support real-time reading of gzip log files (#22)
 
 ### Bug fix
 
 ### Improvements
 - Add metrics enable to the main config (#23)
-
-||||||| 60a926b
-=======
-## Latest (In development)
-
-### Breaking changes
-
-### Features
-- Support real-time reading of gzip log files
-
-### Bug fix
-### Improvements
->>>>>>> main
+- 
 ## 1.28.2 (2025-02-15)
 
 This release includes updates from the underlying [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -7,6 +7,17 @@ title: "版本历史"
 
 这里是 INFINI Agent 历史版本发布的相关说明。
 
+## Latest (In development)
+
+### Breaking changes
+
+### Features
+
+### Bug fix
+
+### Improvements
+- 默认开启指标采集配置 (#23)
+
 ## 1.28.2 (2025-02-15)
 
 ### Improvements


### PR DESCRIPTION
## What does this PR do
This pull request includes a small but significant change to the `agent.yml` file. The change enables metrics collection for the agent.

* [`agent.yml`](diffhunk://#diff-bbed0c0c838791ede65a5518e6999091ddc5190d17a50384f3f97f533447fe3dR52-R54): Added a `metrics` section with `enabled: true` to enable metrics collection for the agent.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation