### PR TITLE
feat: adapt log level to ECSJsonLayout format

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -13,6 +13,7 @@ Information about release notes of INFINI Agent is provided here.
 
 ### Features
 - Support real-time reading of gzip log files (#22)
+- Adapt log level to ECSJsonLayout format (#24)
 
 ### Bug fix
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,7 +12,8 @@ title: "版本历史"
 ### Breaking changes
 
 ### Features
-- 支持实时查看 gzip 压缩的日志文件 (#23)
+- 支持实时查看 gzip 压缩的日志文件 (#22)
+- 采集日志级别适配 ECSJsonLayout 格式 (#24)
 
 ### Bug fix
 

--- a/plugin/logs/logs.go
+++ b/plugin/logs/logs.go
@@ -315,6 +315,11 @@ func (p *LogsProcessor) Save(event FSEvent, logContent util.MapStr, timestamp st
 	logEvent.Meta = util.MapStr{
 		"log_type": event.Pattern.Type,
 	}
+	// adapt log level to ECSJsonLayout format
+	if level, exists := logContent["log.level"]; exists {
+		logContent["level"] = level
+		delete(logContent, "log.level")
+	}
 	logEvent.Meta.Update(p.cfg.Metadata)
 	logEvent.Meta.Update(event.Pattern.Metadata)
 	logEvent.Meta["file"] = File{


### PR DESCRIPTION
## What does this PR do
This pull request includes a change to the `plugin/logs/logs.go` file to adapt the log level to the ECSJsonLayout format.

* [`plugin/logs/logs.go`](diffhunk://#diff-a7b1326227ecb12e1582552931da46478ac4f43a283782d238c3af88bca89d9bR318-R322): Added code to map `log.level` to `level` and remove the original `log.level` key from the `logContent` map.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation