### PR TITLE
docs: add outputs json

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -7,6 +7,12 @@ theme: book
 disablePathToLower: true
 enableGitInfo: false
 
+outputs:
+  home:
+    - HTML
+    - RSS
+    - JSON
+
 # Needed for mermaid/katex shortcodes
 markup:
   goldmark:


### PR DESCRIPTION
## What does this PR do
This pull request includes a change to the `docs/config.yaml` file to enhance the output formats for the `theme: book`. The most important change is the addition of multiple output formats for the home page.

Enhancements to output formats:

* [`docs/config.yaml`](diffhunk://#diff-06e23ea20a066a0e717b5eaa625dfd3f1d11439f4ad5bd705d16d6e1758b39c0R10-R15): Added `HTML`, `RSS`, and `JSON` as output formats for the home page under the `outputs` section.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation