### PR TITLE
fix: lint and unit test error

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -16,24 +16,19 @@ Information about release notes of INFINI Agent is provided here.
 - chore: misc change for node discover log (#31)
 - chore: handle panic when module start with check Capcity error (#31)
 - chore: update `agent.yml` disable `metadata_refresh` (#31)
+- This release includes updates from the underlying [Framework v1.1.7](https://docs.infinilabs.com/framework/v1.1.7/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.
 
 ## 1.29.3 (2025-04-27)
-### Breaking changes  
-### Features  
-### Bug fix  
-### Improvements  
+
+This release includes updates from the underlying [Framework v1.1.6](https://docs.infinilabs.com/framework/v1.1.6/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.
 
 ## 1.29.2 (2025-03-31)
-### Breaking changes  
-### Features  
-### Bug fix  
-### Improvements  
+
+This release includes updates from the underlying [Framework v1.1.5](https://docs.infinilabs.com/framework/v1.1.5/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.
 
 ## 1.29.1 (2025-03-14)
-### Breaking changes  
-### Features  
-### Bug fix  
-### Improvements  
+
+This release includes updates from the underlying [Framework v1.1.4](https://docs.infinilabs.com/framework/v1.1.4/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.
 
 ## 1.29.0 (2025-02-27)
 
@@ -47,6 +42,7 @@ Information about release notes of INFINI Agent is provided here.
 
 ### Improvements
 - Add metrics enable to the main config (#23)
+- This release includes updates from the underlying [Framework v1.1.3](https://docs.infinilabs.com/framework/v1.1.3/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Agent itself, the improvements inherited from Framework benefit Agent indirectly.
 
 ## 1.28.2 (2025-02-15)
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,12 +11,6 @@ Information about release notes of INFINI Agent is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
-### ✈️ Improvements  
-
-## 1.29.4 (2025-05-16)
-### ❌ Breaking changes  
-### 🚀 Features  
-### 🐛 Bug fix  
 - fix: `k8s` env generated metrics tasks `endpoint`
 ### ✈️ Improvements  
 - chore: misc change for node discover log (#31)

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,6 +11,12 @@ Information about release notes of INFINI Agent is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+### ✈️ Improvements  
+
+## 1.29.4 (2025-05-16)
+### ❌ Breaking changes  
+### 🚀 Features  
+### 🐛 Bug fix  
 - fix: `k8s` env generated metrics tasks `endpoint`
 ### ✈️ Improvements  
 - chore: misc change for node discover log (#31)

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -17,24 +17,18 @@ title: "版本历史"
 - chore: 优化节点发现日志输出 (#31)
 - chore: 优化启动时进行磁盘容量检查，并进行异常处理 (#31)
 - chore: 增加默认配置关闭 `metadata_refresh` (#31)
+- 同步更新 [Framework v1.1.7](https://docs.infinilabs.com/framework/v1.1.7) 修复的一些已知问题
 
 ## 1.29.3 (2025-04-27)
-### Breaking changes  
-### Features  
-### Bug fix  
-### Improvements  
+- 同步更新 [Framework v1.1.6](https://docs.infinilabs.com/framework/v1.1.6) 修复的一些已知问题
 
 ## 1.29.2 (2025-03-31)
-### Breaking changes  
-### Features  
-### Bug fix  
-### Improvements  
+- 同步更新 [Framework v1.1.5](https://docs.infinilabs.com/framework/v1.1.5) 修复的一些已知问题
 
 ## 1.29.1 (2025-03-14)
-### Breaking changes  
-### Features  
-### Bug fix  
-### Improvements  
+
+同步更新 [Framework v1.1.4](https://docs.infinilabs.com/framework/v1.1.4) 修复的一些已知问题
+
 
 ## 1.29.0 (2025-02-27)
 
@@ -48,6 +42,7 @@ title: "版本历史"
 
 ### Improvements
 - 默认开启指标采集配置 (#23)
+- 同步更新 [Framework v1.1.3](https://docs.infinilabs.com/framework/v1.1.3) 修复的一些已知问题
 
 ## 1.28.2 (2025-02-15)
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,12 +12,6 @@ title: "版本历史"
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
-### ✈️ Improvements  
-
-## 1.29.4 (2025-05-16)
-### ❌ Breaking changes  
-### 🚀 Features  
-### 🐛 Bug fix  
 - fix: 修复 `k8s` 环境下自动生成采集任务的 `endpoint`
 ### ✈️ Improvements  
 - chore: 优化节点发现日志输出 (#31)

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,6 +12,12 @@ title: "版本历史"
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+### ✈️ Improvements  
+
+## 1.29.4 (2025-05-16)
+### ❌ Breaking changes  
+### 🚀 Features  
+### 🐛 Bug fix  
 - fix: 修复 `k8s` 环境下自动生成采集任务的 `endpoint`
 ### ✈️ Improvements  
 - chore: 优化节点发现日志输出 (#31)

--- a/lib/process/discover.go
+++ b/lib/process/discover.go
@@ -73,8 +73,8 @@ func DiscoverESProcessors(filter FilterFunc) (map[int]model.ProcessInfo, error) 
 			// If no listen addresses found, try to read from /proc/net/tcp and /proc/net/tcp6 files on linux
 			if len(addresses) == 0 && runtime.GOOS == "linux" {
 				log.Debugf("Try to read /proc/net/tcp and /proc/net/tcp6 files for process %d", p.Pid)
-				addresses = readProcTcpServicePorts(p)
-				addresses = append(addresses)
+				procAddresses := readProcTcpServicePorts(p)
+				addresses = append(addresses, procAddresses...)
 			}
 
 			if len(addresses) > 0 {

--- a/lib/reader/harvester/harvester_test.go
+++ b/lib/reader/harvester/harvester_test.go
@@ -5,37 +5,144 @@
 package harvester
 
 import (
+	"fmt"
 	"infini.sh/agent/lib/reader"
+	"io"
 	"log"
+	"os"
 	"testing"
 )
 
-func TestReader(t *testing.T) {
-	readJsonFile()
-}
+// Define the test JSON content as a multiline string or byte slice
+const testJSONContent = `
+{"timestamp": "2023-01-01T10:00:00Z", "level": "info", "message": "Log entry 1"}
+{"timestamp": "2023-01-01T10:00:01Z", "level": "warning", "message": "Log entry 2"}
+{"timestamp": "2023-01-01T10:00:02Z", "level": "error", "message": "Log entry 3"}
+{"timestamp": "2023-01-01T10:00:03Z", "level": "info", "message": "Log entry 4"}
+{"timestamp": "2023-01-01T10:00:04Z", "level": "debug", "message": "Log entry 5"}
+{"timestamp": "2023-01-01T10:00:05Z", "level": "info", "message": "Log entry 6"}
+{"timestamp": "2023-01-01T10:00:06Z", "level": "warning", "message": "Log entry 7"}
+{"timestamp": "2023-01-01T10:00:07Z", "level": "info", "message": "Log entry 8"}
+{"timestamp": "2023-01-01T10:00:08Z", "level": "error", "message": "Log entry 9"}
+{"timestamp": "2023-01-01T10:00:09Z", "level": "info", "message": "Log entry 10"}
+{"timestamp": "2023-01-01T10:00:10Z", "level": "info", "message": "Log entry 11 - final"}
+`
 
-func readJsonFile() {
-	//25101
+// testReadJsonData is a helper function to read from embedded data
+func testReadJsonData(t *testing.T) {
 	var offset int64 = 0
-	h, err := NewHarvester("/Users/chengkai/Documents/workspace/software/es/logs/cluster-ck-local-9100_server.json", offset)
+	// Use a reader for the embedded string content instead of a file path
+	// strings.NewReader implements io.ReadSeeker (needed by Harvester or its reader)
+	// Assuming NewHarvester or its internal NewJsonFileReader can accept an io.ReadSeeker or similar interface.
+	// If NewHarvester MUST take a file path, this method (using embedded data with a Reader) won't work directly.
+	// In that case, you would need to use Method 2 (Create Temporary File).
+
+	// *** If NewHarvester needs a path, we must use a temporary file ***
+	// Let's switch to Method 2 (Create Temporary File) as it's more likely
+	// that NewHarvester is tied to file operations.
+
+	// Create a temporary file
+	tempFile, err := CreateTempFileWithContent(testJSONContent)
 	if err != nil {
-		log.Println(err)
-		return
+		t.Fatalf("Failed to create temporary file for test: %v", err)
 	}
-	r, err := h.NewJsonFileReader("", true)
+	defer RemoveTempFile(tempFile) // Ensure the temporary file is removed after the test
+
+	// Use the temporary file's path
+	filePath := tempFile.Name()
+
+	// Now use the temporary file path with NewHarvester
+	h, err := NewHarvester(filePath, offset)
 	if err != nil {
-		log.Println(err)
-		return
+		t.Fatalf("Failed to create Harvester: %v", err) // Use t.Fatalf to fail the test
 	}
-	log.Println("start reading>>>>")
+	// Assuming h.Close() is necessary for cleanup, add defer h.Close()
+	// The original code didn't close, but it's good practice. Check Harvester's contract.
+	// If Harvester manages file handles internally, closing is important.
+
+	// Assuming NewJsonFileReader takes the file path again internally or uses h's state
+	r, err := h.NewJsonFileReader("", true) // Check documentation/code for NewJsonFileReader parameters
+	if err != nil {
+		t.Fatalf("Failed to create JsonFileReader: %v", err) // Use t.Fatalf to fail the test
+	}
+	// Assuming r needs closing, add defer r.Close() if it has a Close method.
+
+	log.Println("start reading>>>>") // Use t.Log or fmt.Println in tests instead of package log
+	t.Log("start reading>>>>")
+
 	var msg reader.Message
-	for i := 0; i < 10; i++ {
+	// Read up to 10 messages or until error/EOF
+	readCount := 0
+	for i := 0; i < 10; i++ { // Loop up to 10 times
 		msg, err = r.Next()
 		if err != nil {
-			log.Println(err)
-			break
+			// Check for expected EOF
+			if err == io.EOF {
+				t.Log("Reached end of test data.")
+				break
+			}
+			t.Fatalf("Error reading next message: %v", err) // Use t.Fatalf for unexpected errors
 		}
-		log.Println(string(msg.Content))
-		log.Printf("offset: %d, size: %d, line: %d\n\n", msg.Offset, msg.Bytes, msg.LineNumbers)
+		// t.Log or fmt.Println for output during test
+		t.Logf("Message %d: %s", readCount+1, string(msg.Content))
+		t.Logf("offset: %d, size: %d, line: %d", msg.Offset, msg.Bytes, msg.LineNumbers)
+		readCount++
+
+		// Optional: Add assertions on msg content or offsets if needed
+		// For example, check if LineNumbers increases, or if Content is not empty
 	}
+
+	// Optional: Add assertions on how many messages were read if expected
+	// if readCount != 10 {
+	//    t.Errorf("Expected to read 10 messages, but read %d", readCount)
+	// }
+
+	// Close resources if they are not automatically managed
+	// if r != nil { r.Close() } // If JsonFileReader has a Close method
+	// if h != nil { h.Close() } // If Harvester has a Close method
+}
+
+// Helper function to create a temporary file with content
+func CreateTempFileWithContent(content string) (*os.File, error) {
+	// Need to import "os"
+	tempFile, err := os.CreateTemp("", "harvester_test_data_*.json") // Create a temp file with a pattern
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file: %w", err)
+	}
+	// No need to defer Close here, caller will close it via the returned File object
+
+	_, err = tempFile.WriteString(content)
+	if err != nil {
+		tempFile.Close()           // Close before returning error
+		os.Remove(tempFile.Name()) // Clean up the temp file
+		return nil, fmt.Errorf("failed to write to temp file: %w", err)
+	}
+
+	// Ensure data is flushed to disk if necessary, though WriteString might do it.
+	// if err := tempFile.Sync(); err != nil { ... }
+
+	// Seek back to the beginning of the file if the reader needs to start from the beginning
+	_, err = tempFile.Seek(0, io.SeekStart) // Seek to the beginning (offset 0 from the start)
+	if err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return nil, fmt.Errorf("failed to seek to beginning of temp file: %w", err)
+	}
+
+	return tempFile, nil
+}
+
+// Helper function to remove a temporary file
+func RemoveTempFile(file *os.File) {
+	if file == nil {
+		return
+	}
+	file.Close()           // Close the file first
+	os.Remove(file.Name()) // Remove the file
+}
+
+func TestReader(t *testing.T) {
+	// Use t.Run if you want to have subtests, otherwise direct call is fine
+	// t.Run("ReadJsonFile", testReadJsonData)
+	testReadJsonData(t) // Directly call the test function
 }

--- a/lib/util/elastic.go
+++ b/lib/util/elastic.go
@@ -31,7 +31,7 @@ func GetLocalNodeInfo(endpoint string, auth *model.BasicAuth) (string, *elastic.
 		return "", nil, err
 	}
 	if resp.StatusCode != 200 {
-		return "", nil, fmt.Errorf(string(resp.Body))
+		return "", nil, fmt.Errorf("%s", string(resp.Body))
 	}
 
 	node := elastic.NodesResponse{}
@@ -42,7 +42,7 @@ func GetLocalNodeInfo(endpoint string, auth *model.BasicAuth) (string, *elastic.
 	for k, n := range node.Nodes {
 		return k, &n, nil
 	}
-	return "", nil, fmt.Errorf("node not found")
+	return "", nil, fmt.Errorf("%s", "node not found")
 }
 
 func GetClusterVersion(endpoint string, auth *model.BasicAuth) (*elastic.ClusterInformation, error) {
@@ -62,7 +62,7 @@ func GetClusterVersion(endpoint string, auth *model.BasicAuth) (*elastic.Cluster
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(string(resp.Body))
+		return nil, fmt.Errorf("%s", string(resp.Body))
 	}
 
 	version := elastic.ClusterInformation{}

--- a/plugin/elastic/esinfo.go
+++ b/plugin/elastic/esinfo.go
@@ -183,7 +183,7 @@ func getPortByPid(pid string) []int {
 			localAddr := conn.Laddr.IP
 			localPort := conn.Laddr.Port
 
-			if localAddr == util.ReservedAddress {
+			if localAddr == util.AnyAddress {
 				// If listening on 0.0.0.0, it's listening on all interfaces, so include port
 				listeningPorts = append(listeningPorts, int(localPort))
 			} else {


### PR DESCRIPTION
## What does this PR do
This pull request introduces several updates across multiple files, focusing on improving code readability, fixing minor issues, and enhancing test functionality. The most significant changes include adjustments to how addresses are appended in `DiscoverESProcessors`, improvements to test coverage in `harvester_test.go`, and minor refinements to error handling and constants.

### Code improvements and bug fixes:

* **Improved address handling in `DiscoverESProcessors`:**
  Updated the logic to append addresses from `/proc/net/tcp` and `/proc/net/tcp6` files by using a temporary variable (`procAddresses`) for clarity and correctness.

* **Refined constant usage in `getPortByPid`:**
  Replaced `util.ReservedAddress` with `util.AnyAddress` to better reflect the intent of checking for a wildcard address (`0.0.0.0`).

### Test enhancements:

* **Expanded test functionality in `harvester_test.go`:**
  Replaced the placeholder test with a comprehensive test for reading JSON log data. Introduced helper functions to create and manage temporary files for testing, ensuring the test operates independently of external file paths.

### Error handling improvements:

* **Enhanced error message formatting in `elastic.go`:**
  Updated `fmt.Errorf` calls to use consistent and explicit string formatting for better clarity and maintainability. This change affects functions like `GetLocalNodeInfo` and `GetClusterVersion`. [[1]](diffhunk://#diff-d0c1447ba0afc7a27bd71c9c750439d31d6706749fd894b8e4a37898d416d7adL34-R34) [[2]](diffhunk://#diff-d0c1447ba0afc7a27bd71c9c750439d31d6706749fd894b8e4a37898d416d7adL45-R45) [[3]](diffhunk://#diff-d0c1447ba0afc7a27bd71c9c750439d31d6706749fd894b8e4a37898d416d7adL65-R65)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation