### PR TITLE
feat: use 'http.port' env var to detect EasySearch HTTP port in Kuber…

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,6 +10,7 @@ Information about release notes of INFINI Agent is provided here.
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- feat: use 'http.port' env var to detect EasySearch HTTP port in Kubernetes
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -11,6 +11,7 @@ title: "版本历史"
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- feat: 在 Kubernetes 环境下通过环境变量 `http.port` 探测 EasySearch 的 HTTP 端口
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 


### PR DESCRIPTION
use 'http.port' env var to detect EasySearch HTTP port in Kubernetes

## What does this PR do

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation