### PR TITLE
 feat: enable CORS support for discovery & logs APIs

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,6 +10,9 @@ Information about release notes of INFINI Agent is provided here.
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+
+- feat: enable CORS support for discovery & logs APIs #63
+
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -4,7 +4,10 @@
 
 package api
 
-import "infini.sh/framework/core/api"
+import (
+	"infini.sh/framework/core/api"
+	"infini.sh/framework/modules/security/http_filters"
+)
 
 type AgentAPI struct {
 	api.Handler
@@ -14,8 +17,12 @@ func InitAPI() {
 	agentAPI := AgentAPI{}
 
 	// Discovery & logs — require login
-	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.getESNodes, api.RequireLogin())
-	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin())
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles, api.RequireLogin())
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile, api.RequireLogin())
+	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.getESNodes, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
+	api.HandleUIMethod(api.OPTIONS, "/elasticsearch/node/_discovery", agentAPI.getESNodes, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
+	api.HandleUIMethod(api.OPTIONS, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
+	api.HandleUIMethod(api.OPTIONS, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
+	api.HandleUIMethod(api.OPTIONS, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile, api.RequireLogin(), api.Feature(http_filters.FeatureCORS))
 }


### PR DESCRIPTION
## What does this PR do

 Enable CORS support for discovery & logs APIs registered in `plugin/api/init.go`

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation