### PR TITLE
chore: git ignore .vscode and plugin/enterprise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ config/generated.go
 config/generat*.go
 config/*.tpl
 config/*.yml
+.vscode
+# Enterprise plugin
+plugin/enterprise

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -13,6 +13,8 @@ Information about release notes of INFINI Agent is provided here.
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 
+- chore: git ignore .vscode and plugin/enterprise #69
+
 ## 1.31.0 (2026-04-18)
 ### ❌ Breaking changes  
 ### 🚀 Features  

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -14,6 +14,8 @@ title: "版本历史"
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 
+- chore: 让 git 忽略 .vscode 和 plugin/enterprise #69
+
 ## 1.31.0 (2026-04-18)
 ### ❌ Breaking changes  
 ### 🚀 Features  


### PR DESCRIPTION
Git-ignore 

1. `.vscode`: This project uses GOPATH, so the language server needs to be configured accordingly via .vscode/settings.json.
2. the enterprise plugin

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation