### PR TITLE
feat: pluggable event sink for cluster/index/node stats and cluster health collectors

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,6 +10,8 @@ Information about release notes of INFINI Agent is provided here.
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- feat: pluggable event sink for cluster/index/node stats and cluster health collectors #74
+
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - chore: update security settings #70

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -11,6 +11,8 @@ title: "版本历史"
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- feat: 让集群/索引/节点stats和集群健康collectors支持可插拔的存储sink #74
+
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 

--- a/plugin/elastic/metric/cluster_health/cluster_health.go
+++ b/plugin/elastic/metric/cluster_health/cluster_health.go
@@ -5,7 +5,9 @@
 package cluster_health
 
 import (
+	"context"
 	"fmt"
+
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/elastic"
@@ -29,6 +31,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 	}
 	processor := ClusterHealth{
 		config: &cfg,
+		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)
 	if err != nil {
@@ -44,6 +47,17 @@ type Config struct {
 
 type ClusterHealth struct {
 	config *Config
+	event.EventSink
+}
+
+// NewCollector creates a ClusterHealth collector with a custom sink.
+func NewCollector(cfg *Config, sink event.EventSink) *ClusterHealth {
+	collector := ClusterHealth{
+		config: cfg,
+	}
+	collector.EventSink = sink
+
+	return &collector
 }
 
 func (p *ClusterHealth) Name() string {
@@ -65,7 +79,7 @@ func (p *ClusterHealth) Collect(k string, v *elastic.ElasticsearchMetadata) erro
 	}
 	var health *elastic.ClusterHealth
 	var err error
-	health, err = client.ClusterHealthSpecEndpoint(nil, v.Config.GetAnyEndpoint(), "")
+	health, err = client.ClusterHealthSpecEndpoint(context.Background(), v.Config.GetAnyEndpoint(), "")
 	if err != nil {
 		log.Error(v.Config.Name, " get cluster health error: ", err)
 		return err
@@ -93,5 +107,5 @@ func (p *ClusterHealth) Collect(k string, v *elastic.ElasticsearchMetadata) erro
 			"cluster_health": health,
 		},
 	}
-	return event.Save(&item)
+	return p.Save(&item)
 }

--- a/plugin/elastic/metric/cluster_health/cluster_health.go
+++ b/plugin/elastic/metric/cluster_health/cluster_health.go
@@ -30,7 +30,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 		return nil, fmt.Errorf("failed to unpack the configuration of %s processor: %s", processorName, err)
 	}
 	processor := ClusterHealth{
-		config: &cfg,
+		config:    &cfg,
 		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)

--- a/plugin/elastic/metric/cluster_stats/cluster_stats.go
+++ b/plugin/elastic/metric/cluster_stats/cluster_stats.go
@@ -5,7 +5,9 @@
 package cluster_stats
 
 import (
+	"context"
 	"fmt"
+
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/elastic"
@@ -29,6 +31,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 	}
 	processor := ClusterStats{
 		config: &cfg,
+		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)
 	if err != nil {
@@ -44,6 +47,17 @@ type Config struct {
 
 type ClusterStats struct {
 	config *Config
+	event.EventSink
+}
+
+// NewCollector creates a ClusterStats collector with a custom sink.
+func NewCollector(cfg *Config, sink event.EventSink) *ClusterStats {
+	collector := ClusterStats{
+		config: cfg,
+	}
+	collector.EventSink = sink
+
+	return &collector
 }
 
 func (p *ClusterStats) Name() string {
@@ -66,7 +80,7 @@ func (p *ClusterStats) Collect(k string, v *elastic.ElasticsearchMetadata) error
 
 	var stats *elastic.ClusterStats
 	var err error
-	stats, err = client.GetClusterStatsSpecEndpoint(nil, "", v.Config.GetAnyEndpoint())
+	stats, err = client.GetClusterStatsSpecEndpoint(context.Background(), "", v.Config.GetAnyEndpoint())
 	if err != nil {
 		log.Error(v.Config.Name, " get cluster stats error: ", err)
 		return err
@@ -95,5 +109,5 @@ func (p *ClusterStats) Collect(k string, v *elastic.ElasticsearchMetadata) error
 		},
 	}
 
-	return event.Save(&item)
+	return p.Save(&item)
 }

--- a/plugin/elastic/metric/cluster_stats/cluster_stats.go
+++ b/plugin/elastic/metric/cluster_stats/cluster_stats.go
@@ -30,7 +30,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 		return nil, fmt.Errorf("failed to unpack the configuration of %s processor: %s", processorName, err)
 	}
 	processor := ClusterStats{
-		config: &cfg,
+		config:    &cfg,
 		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)

--- a/plugin/elastic/metric/index_stats/index_stats.go
+++ b/plugin/elastic/metric/index_stats/index_stats.go
@@ -6,6 +6,7 @@ package index_stats
 
 import (
 	"fmt"
+
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/elastic"
@@ -33,6 +34,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 	}
 	processor := IndexStats{
 		config: &cfg,
+		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)
 	if err != nil {
@@ -51,6 +53,17 @@ type Config struct {
 
 type IndexStats struct {
 	config *Config
+	event.EventSink
+}
+
+// NewCollector creates an IndexStats collector with a custom sink.
+func NewCollector(cfg *Config, sink event.EventSink) *IndexStats {
+	collector := IndexStats{
+		config: cfg,
+	}
+	collector.EventSink = sink
+
+	return &collector
 }
 
 func (p *IndexStats) Name() string {
@@ -163,5 +176,5 @@ func (p *IndexStats) SaveIndexStats(clusterId, clusterUUID, indexID, indexName s
 		},
 	}
 
-	event.Save(&item)
+	p.Save(&item)
 }

--- a/plugin/elastic/metric/index_stats/index_stats.go
+++ b/plugin/elastic/metric/index_stats/index_stats.go
@@ -33,7 +33,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 		return nil, fmt.Errorf("failed to unpack the configuration of %s processor: %s", processorName, err)
 	}
 	processor := IndexStats{
-		config: &cfg,
+		config:    &cfg,
 		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)

--- a/plugin/elastic/metric/node_stats/node_stats.go
+++ b/plugin/elastic/metric/node_stats/node_stats.go
@@ -6,6 +6,9 @@ package node_stats
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/elastic"
@@ -13,8 +16,6 @@ import (
 	"infini.sh/framework/core/pipeline"
 	"infini.sh/framework/core/util"
 	"infini.sh/framework/modules/elastic/adapter"
-	"strings"
-	"time"
 )
 
 const processorName = "es_node_stats"
@@ -35,6 +36,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 	cfg.NodeUUIDs = append(nodeUUIDs, cfg.NodeUUIDs...)
 	processor := NodeStats{
 		config: &cfg,
+		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)
 	if err != nil {
@@ -52,6 +54,17 @@ type Config struct {
 
 type NodeStats struct {
 	config *Config
+	event.EventSink
+}
+
+// NewCollector creates a NodeStats collector with a custom sink.
+func NewCollector(cfg *Config, sink event.EventSink) *NodeStats {
+	collector := NodeStats{
+		config: cfg,
+	}
+	collector.EventSink = sink
+
+	return &collector
 }
 
 func (p *NodeStats) Name() string {
@@ -218,7 +231,7 @@ func (p *NodeStats) SaveNodeStats(clusterId, clusterUUID, nodeID string, f, shar
 			"node_stats": x,
 		},
 	}
-	err := event.SaveWithTimestamp(&item, timestamp)
+	err := p.SaveWithTimestamp(&item, timestamp)
 	if err != nil {
 		log.Error(err)
 	}
@@ -280,7 +293,7 @@ func (p *NodeStats) SaveShardStats(clusterId, clusterUUID, nodeID, host, indexNa
 			"shard_stats": x,
 		},
 	}
-	err := event.SaveWithTimestamp(&item, timestamp)
+	err := p.SaveWithTimestamp(&item, timestamp)
 	if err != nil {
 		panic(err)
 	}

--- a/plugin/elastic/metric/node_stats/node_stats.go
+++ b/plugin/elastic/metric/node_stats/node_stats.go
@@ -35,7 +35,7 @@ func newProcessor(c *config.Config) (pipeline.Processor, error) {
 	var nodeUUIDs = []string{"_local"}
 	cfg.NodeUUIDs = append(nodeUUIDs, cfg.NodeUUIDs...)
 	processor := NodeStats{
-		config: &cfg,
+		config:    &cfg,
 		EventSink: event.DefaultEventSink,
 	}
 	_, err := adapter.GetClusterUUID(processor.config.Elasticsearch)


### PR DESCRIPTION
## What does this PR do

Add pluggable event sink for cluster/index/node stats and cluster health collectors so that they can be reused in the enterprise plugin.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation