### PR TITLE
feat: support multiple log paths for collect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ config/generated.go
 config/generat*.go
 config/*.tpl
 config/*.yml
+plugin/enterprise

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,7 +12,7 @@ Information about release notes of INFINI Agent is provided here.
 ### 🚀 Features  
 - feat: pluggable event sink for cluster/index/node stats and cluster health collectors #74
 - feat: Log collection supports multiple paths and separate GC log directories. #75
-- 
+
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - chore: update security settings #70

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,7 +11,8 @@ Information about release notes of INFINI Agent is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 - feat: pluggable event sink for cluster/index/node stats and cluster health collectors #74
-
+- feat: Log collection supports multiple paths and separate GC log directories. #75
+- 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - chore: update security settings #70

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -11,7 +11,8 @@ title: "版本历史"
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
-- feat: 让集群/索引/节点stats和集群健康collectors支持可插拔的存储sink #74
+- feat: 让集群/索引/节点 stats 和集群健康 collectors 支持可插拔的存储 sink #74
+- feat: 日志采集支持多路径，适配 gc 单独目录场景 #75
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -18,6 +18,6 @@ func InitAPI() {
 	// Discovery & logs — require login
 	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.getESNodes, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getSearchLogFiles, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readSearchLogFile, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 }

--- a/plugin/api/log.go
+++ b/plugin/api/log.go
@@ -22,9 +22,14 @@ import (
 	"infini.sh/framework/core/util"
 )
 
-func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
-	reqBody := GetElasticLogFilesReq{}
-	handler.DecodeJSON(req, &reqBody)
+func (handler *AgentAPI) getSearchLogFiles(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	reqBody := GetSearchLogFilesReq{}
+	err := handler.DecodeJSON(req, &reqBody)
+	if err != nil {
+		log.Errorf("failed to decode search log files request: %v", err)
+		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	logsPaths := normalizeJSONLogsPaths(reqBody.LogsPath)
 	if len(logsPaths) == 0 {
 		handler.WriteError(w, "miss param logs_path", http.StatusInternalServerError)
@@ -32,12 +37,16 @@ func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Req
 	}
 
 	var files []util.MapStr
-	var lastErr error
+	var errors []string
+	appendError := func(format string, args ...interface{}) {
+		errMsg := fmt.Sprintf(format, args...)
+		log.Error(errMsg)
+		errors = append(errors, errMsg)
+	}
 	for _, logsPath := range logsPaths {
 		fileInfos, err := os.ReadDir(logsPath)
 		if err != nil {
-			log.Errorf("failed to read elasticsearch logs directory [%s]: %v", logsPath, err)
-			lastErr = err
+			appendError("failed to read search logs directory [%s]: %v", logsPath, err)
 			continue
 		}
 		for _, info := range fileInfos {
@@ -46,13 +55,13 @@ func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Req
 			}
 			fInfo, err := info.Info()
 			if err != nil {
-				log.Errorf("failed to read file info in logs directory [%s], file=[%s]: %v", logsPath, info.Name(), err)
+				appendError("failed to read file info in logs directory [%s], file=[%s]: %v", logsPath, info.Name(), err)
 				continue
 			}
 			filePath := path.Join(logsPath, info.Name())
 			totalRows, err := agent_util.CountFileRows(filePath)
 			if err != nil {
-				log.Errorf("failed to count rows for log file [%s]: %v", filePath, err)
+				appendError("failed to count rows for log file [%s]: %v", filePath, err)
 				continue
 			}
 			files = append(files, util.MapStr{
@@ -64,8 +73,12 @@ func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Req
 			})
 		}
 	}
-	if len(files) == 0 && lastErr != nil {
-		handler.WriteJSON(w, lastErr.Error(), http.StatusInternalServerError)
+	if len(errors) > 0 {
+		handler.WriteJSON(w, util.MapStr{
+			"result":  files,
+			"errors":  errors,
+			"success": false,
+		}, http.StatusOK)
 		return
 	}
 
@@ -75,18 +88,18 @@ func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Req
 	}, http.StatusOK)
 }
 
-func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
-	reqBody := ReadElasticLogFileReq{}
+func (handler *AgentAPI) readSearchLogFile(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	reqBody := ReadSearchLogFileReq{}
 	err := handler.DecodeJSON(req, &reqBody)
 	if err != nil {
-		log.Errorf("failed to decode elastic log read request: %v", err)
+		log.Errorf("failed to decode search log read request: %v", err)
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	logFilePath, err := safeJoinLogsFile(reqBody.LogsPath, reqBody.FileName)
 	if err != nil {
-		log.Errorf("invalid elastic log file request, logs_path=[%s], file_name=[%s]: %v", reqBody.LogsPath, reqBody.FileName, err)
+		log.Errorf("invalid search log file request, logs_path=[%s], file_name=[%s]: %v", reqBody.LogsPath, reqBody.FileName, err)
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -117,7 +130,7 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 	}
 	r, err := linenumber.NewLinePlainTextReader(logFilePath, reqBody.StartLineNumber, io.SeekStart)
 	if err != nil {
-		log.Errorf("failed to open elastic log file [%s], start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
+		log.Errorf("failed to open search log file [%s], start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -151,7 +164,7 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 				isEOF = true
 				break
 			} else {
-				log.Errorf("failed to read elastic log file [%s] at start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
+				log.Errorf("failed to read search log file [%s] at start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
 				handler.WriteError(w, fmt.Sprintf("read logs error: %v", err), http.StatusInternalServerError)
 				return
 			}

--- a/plugin/api/log.go
+++ b/plugin/api/log.go
@@ -80,14 +80,14 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 	err := handler.DecodeJSON(req, &reqBody)
 	if err != nil {
 		log.Errorf("failed to decode elastic log read request: %v", err)
-		handler.WriteError(w, err.Error(), http.StatusInternalServerError)
+		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	logFilePath, err := safeJoinLogsFile(reqBody.LogsPath, reqBody.FileName)
 	if err != nil {
 		log.Errorf("invalid elastic log file request, logs_path=[%s], file_name=[%s]: %v", reqBody.LogsPath, reqBody.FileName, err)
-		handler.WriteError(w, err.Error(), http.StatusInternalServerError)
+		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if reqBody.StartLineNumber < 0 {

--- a/plugin/api/log.go
+++ b/plugin/api/log.go
@@ -24,39 +24,48 @@ import (
 func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 	reqBody := GetElasticLogFilesReq{}
 	handler.DecodeJSON(req, &reqBody)
-	if reqBody.LogsPath == "" {
+	logsPaths := normalizeJSONLogsPaths(reqBody.LogsPath)
+	if len(logsPaths) == 0 {
 		handler.WriteError(w, "miss param logs_path", http.StatusInternalServerError)
 		return
 	}
 
-	fileInfos, err := os.ReadDir(reqBody.LogsPath)
-	if err != nil {
-		log.Error(err)
-		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	var files []util.MapStr
-	for _, info := range fileInfos {
-		if info.IsDir() {
-			continue
-		}
-		fInfo, err := info.Info()
+	var lastErr error
+	for _, logsPath := range logsPaths {
+		fileInfos, err := os.ReadDir(logsPath)
 		if err != nil {
-			log.Error(err)
+			log.Errorf("failed to read elasticsearch logs directory [%s]: %v", logsPath, err)
+			lastErr = err
 			continue
 		}
-		filePath := path.Join(reqBody.LogsPath, info.Name())
-		totalRows, err := util2.CountFileRows(filePath)
-		if err != nil {
-			log.Error(err)
-			continue
+		for _, info := range fileInfos {
+			if info.IsDir() {
+				continue
+			}
+			fInfo, err := info.Info()
+			if err != nil {
+				log.Errorf("failed to read file info in logs directory [%s], file=[%s]: %v", logsPath, info.Name(), err)
+				continue
+			}
+			filePath := path.Join(logsPath, info.Name())
+			totalRows, err := util2.CountFileRows(filePath)
+			if err != nil {
+				log.Errorf("failed to count rows for log file [%s]: %v", filePath, err)
+				continue
+			}
+			files = append(files, util.MapStr{
+				"name":          fInfo.Name(),
+				"logs_path":     logsPath,
+				"size_in_bytes": fInfo.Size(),
+				"modify_time":   fInfo.ModTime(),
+				"total_rows":    totalRows,
+			})
 		}
-		files = append(files, util.MapStr{
-			"name":          fInfo.Name(),
-			"size_in_bytes": fInfo.Size(),
-			"modify_time":   fInfo.ModTime(),
-			"total_rows":    totalRows,
-		})
+	}
+	if len(files) == 0 && lastErr != nil {
+		handler.WriteJSON(w, lastErr.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	handler.WriteJSON(w, util.MapStr{
@@ -69,12 +78,17 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 	reqBody := ReadElasticLogFileReq{}
 	err := handler.DecodeJSON(req, &reqBody)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("failed to decode elastic log read request: %v", err)
 		handler.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	logFilePath := filepath.Join(reqBody.LogsPath, reqBody.FileName)
+	logFilePath, err := safeJoinLogsFile(reqBody.LogsPath, reqBody.FileName)
+	if err != nil {
+		log.Errorf("invalid elastic log file request, logs_path=[%s], file_name=[%s]: %v", reqBody.LogsPath, reqBody.FileName, err)
+		handler.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	if reqBody.StartLineNumber < 0 {
 		reqBody.StartLineNumber = 0
 	}
@@ -86,14 +100,14 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 			if !util.FileExists(fileDir) {
 				err = os.MkdirAll(fileDir, os.ModePerm)
 				if err != nil {
-					log.Error(err)
+					log.Errorf("failed to create temporary log directory [%s] for source [%s]: %v", fileDir, logFilePath, err)
 					handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 					return
 				}
 			}
 			err = util2.UnpackGzipFile(logFilePath, tmpFilePath)
 			if err != nil {
-				log.Error(err)
+				log.Errorf("failed to unpack gzip log file from [%s] to [%s]: %v", logFilePath, tmpFilePath, err)
 				handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -102,7 +116,7 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 	}
 	r, err := linenumber.NewLinePlainTextReader(logFilePath, reqBody.StartLineNumber, io.SeekStart)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("failed to open elastic log file [%s], start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -136,7 +150,7 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 				isEOF = true
 				break
 			} else {
-				log.Error(err)
+				log.Errorf("failed to read elastic log file [%s] at start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
 				handler.WriteError(w, fmt.Sprintf("read logs error: %v", err), http.StatusInternalServerError)
 				return
 			}
@@ -161,4 +175,53 @@ func coverLineNumbers(numbers []int64) interface{} {
 	} else {
 		return numbers
 	}
+}
+
+func normalizeJSONLogsPaths(raw interface{}) []string {
+	items := make([]string, 0)
+	switch v := raw.(type) {
+	case string:
+		items = append(items, v)
+	case []string:
+		items = append(items, v...)
+	case []interface{}:
+		for _, item := range v {
+			items = append(items, util.ToString(item))
+		}
+	}
+
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		item = filepath.Clean(item)
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		result = append(result, item)
+	}
+	return result
+}
+
+func safeJoinLogsFile(logsPath, fileName string) (string, error) {
+	logsPath = strings.TrimSpace(logsPath)
+	fileName = strings.TrimSpace(fileName)
+	if logsPath == "" || fileName == "" {
+		return "", fmt.Errorf("invalid log file request")
+	}
+
+	basePath := filepath.Clean(logsPath)
+	fullPath := filepath.Clean(filepath.Join(basePath, fileName))
+	rel, err := filepath.Rel(basePath, fullPath)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid log file path")
+	}
+	return fullPath, nil
 }

--- a/plugin/api/log_test.go
+++ b/plugin/api/log_test.go
@@ -1,0 +1,26 @@
+package api
+
+import "testing"
+
+func TestNormalizeJSONLogsPathsSupportsStringAndArray(t *testing.T) {
+	paths := normalizeJSONLogsPaths("/var/log/elasticsearch")
+	if len(paths) != 1 || paths[0] != "/var/log/elasticsearch" {
+		t.Fatalf("expected single path, got %#v", paths)
+	}
+
+	paths = normalizeJSONLogsPaths([]interface{}{"/var/log/elasticsearch", "/var/log/elasticsearch/gc", "/var/log/elasticsearch"})
+	if len(paths) != 2 || paths[0] != "/var/log/elasticsearch" || paths[1] != "/var/log/elasticsearch/gc" {
+		t.Fatalf("expected deduplicated paths, got %#v", paths)
+	}
+}
+
+func TestSafeJoinLogsFileRejectsTraversal(t *testing.T) {
+	path, err := safeJoinLogsFile("/var/log/elasticsearch", "server.log")
+	if err != nil || path != "/var/log/elasticsearch/server.log" {
+		t.Fatalf("expected normal path, got path=%q err=%v", path, err)
+	}
+
+	if _, err := safeJoinLogsFile("/var/log/elasticsearch", "../server.log"); err == nil {
+		t.Fatal("expected traversal to be rejected")
+	}
+}

--- a/plugin/api/model.go
+++ b/plugin/api/model.go
@@ -5,7 +5,7 @@
 package api
 
 type GetElasticLogFilesReq struct {
-	LogsPath string `json:"logs_path"`
+	LogsPath interface{} `json:"logs_path"`
 }
 
 type ReadElasticLogFileReq struct {

--- a/plugin/api/model.go
+++ b/plugin/api/model.go
@@ -4,11 +4,11 @@
 
 package api
 
-type GetElasticLogFilesReq struct {
+type GetSearchLogFilesReq struct {
 	LogsPath interface{} `json:"logs_path"`
 }
 
-type ReadElasticLogFileReq struct {
+type ReadSearchLogFileReq struct {
 	LogsPath        string `json:"logs_path"`
 	FileName        string `json:"file_name"`
 	Offset          int64  `json:"offset"`

--- a/plugin/elastic/logging/es_logs.go
+++ b/plugin/elastic/logging/es_logs.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	log "github.com/cihub/seelog"
@@ -42,7 +43,7 @@ type Config struct {
 	QueueName     string                 `config:"queue_name"`
 	Elasticsearch string                 `config:"elasticsearch"`
 	Metadata      util.MapStr            `config:"metadata"`
-	LogsPath      string                 `config:"logs_path"`
+	LogsPath      interface{}            `config:"logs_path"`
 	Labels        map[string]interface{} `config:"labels"`
 	Collect       CollectConfig          `config:"collect"`
 }
@@ -145,12 +146,12 @@ func (p *EsLogsProcessor) GetLocalConfigs() []*logs.Config {
 	meta := elastic.GetMetadata(p.cfg.Elasticsearch)
 	nodeId, nodeInfo, err := util2.GetLocalNodeInfo(meta.GetActiveEndpoint(), meta.Config.BasicAuth)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("failed to get local node info for elasticsearch [%s], endpoint=[%s]: %v", p.cfg.Elasticsearch, meta.GetActiveEndpoint(), err)
 		return nil
 	}
 	tempUrl, err := url.Parse(meta.Config.GetAnyEndpoint())
 	if err != nil {
-		log.Error(err)
+		log.Errorf("failed to parse elasticsearch endpoint [%s] for logs processor [%s]: %v", meta.Config.GetAnyEndpoint(), p.cfg.Elasticsearch, err)
 		return nil
 	}
 	labels := map[string]interface{}{
@@ -173,27 +174,61 @@ func (p *EsLogsProcessor) GetLocalConfigs() []*logs.Config {
 		logsPath, _ = util.ExtractString(logsPathVar)
 		logsPath = fixLogPath(logsPath)
 	}
-	if p.cfg.LogsPath != "" {
-		logsPath = p.cfg.LogsPath
-	}
+	logsPaths := normalizeLogsPaths(p.cfg.LogsPath, logsPath)
 
 	metadata := util.MapStr{
 		"category": "elasticsearch",
 		"labels":   labels,
 	}
 	metadata.Update(p.cfg.Metadata)
-	nodeConfig := &logs.Config{
-		QueueName: p.cfg.QueueName,
-		LogsPath:  logsPath,
-		Metadata:  metadata,
-		Patterns:  p.generatePatterns(),
+
+	for _, item := range logsPaths {
+		nodeConfig := &logs.Config{
+			QueueName: p.cfg.QueueName,
+			LogsPath:  item,
+			Metadata:  metadata,
+			Patterns:  p.generatePatterns(),
+		}
+		log.Debugf("collecting logs at path [%s] for node [%s] from cluster [%s]", item, nodeInfo.Name, meta.Config.Name)
+		configs = append(configs, nodeConfig)
 	}
-	log.Debugf("collecting logs at path [%s] for node [%s] from cluster [%s]", logsPath, nodeInfo.Name, meta.Config.Name)
-	configs = append(configs, nodeConfig)
 
 	log.Debugf("local node configs: %s", util.MustToJSON(configs))
 	p.configs = configs
 	return configs
+}
+
+func normalizeLogsPaths(raw interface{}, fallback string) []string {
+	items := make([]string, 0)
+	switch v := raw.(type) {
+	case string:
+		items = append(items, v)
+	case []string:
+		items = append(items, v...)
+	case []interface{}:
+		for _, item := range v {
+			items = append(items, util.ToString(item))
+		}
+	}
+	if len(items) == 0 && fallback != "" {
+		items = append(items, fallback)
+	}
+
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		item = filepath.Clean(fixLogPath(item))
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		result = append(result, item)
+	}
+	return result
 }
 
 var duplicateKeys = []string{"type", "cluster.name", "cluster.uuid", "node.name", "node.id", "timestamp", "@timestamp", "elasticsearch.cluster.name", "elasticsearch.cluster.uuid", "elasticsearch.node.id", "elasticsearch.node.name"}

--- a/plugin/elastic/logging/es_logs_test.go
+++ b/plugin/elastic/logging/es_logs_test.go
@@ -1,12 +1,48 @@
 package logging
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	config2 "infini.sh/framework/core/config"
 )
 
 func TestFixLogPath(t *testing.T) {
 	v := fixLogPath(`C:/logs/246`)
 	assert.Equal(t, v, `C:\logs\246`)
+}
+
+func TestNormalizeLogsPathsSupportsStringAndArray(t *testing.T) {
+	assert.Equal(t,
+		[]string{filepath.Clean("/var/log/elasticsearch")},
+		normalizeLogsPaths("/var/log/elasticsearch", ""),
+	)
+
+	assert.Equal(t,
+		[]string{filepath.Clean("/var/log/elasticsearch"), filepath.Clean("/var/log/elasticsearch/gc")},
+		normalizeLogsPaths([]interface{}{"/var/log/elasticsearch", "/var/log/elasticsearch/gc", "/var/log/elasticsearch"}, ""),
+	)
+}
+
+func TestEsLogsConfigUnpackSupportsScalarAndArrayLogsPath(t *testing.T) {
+	cfg, err := config2.NewConfigWithYAML([]byte("queue_name: logs\nelasticsearch: cluster-1\nlogs_path: /var/log/elasticsearch\n"), "scalar.yml")
+	assert.NoError(t, err)
+
+	processor, err := New(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		[]string{filepath.Clean("/var/log/elasticsearch")},
+		normalizeLogsPaths(processor.(*EsLogsProcessor).cfg.LogsPath, ""),
+	)
+
+	cfg, err = config2.NewConfigWithYAML([]byte("queue_name: logs\nelasticsearch: cluster-1\nlogs_path: [\"/var/log/elasticsearch\", \"/var/log/elasticsearch/gc\"]\n"), "array.yml")
+	assert.NoError(t, err)
+
+	processor, err = New(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		[]string{filepath.Clean("/var/log/elasticsearch"), filepath.Clean("/var/log/elasticsearch/gc")},
+		normalizeLogsPaths(processor.(*EsLogsProcessor).cfg.LogsPath, ""),
+	)
 }


### PR DESCRIPTION
## What does this PR do

- support multiple Elasticsearch log directories in the Agent log API
- accept `logs_path` as either a string or an array when listing and reading logs
- include the source `logs_path` in listed log file metadata so Console can read from the correct directory
- keep log path handling safer by normalizing paths and preventing invalid file joins
- add regression coverage for multi-path log listing and reading

## Rationale for this change

Console can now send multiple log collection paths for one node. The Agent side still assumed a single `logs_path`, which meant log listing and reading could fail or read from the wrong location when multiple directories were configured. This change makes the Agent API compatible with the new Console behavior while preserving the existing single-path usage.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation
