### PR TITLE
feat(api): add agent reverse channel foundation

### DIFF
--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -20,4 +20,5 @@ func InitAPI() {
 	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getSearchLogFiles, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readSearchLogFile, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	registerAgentReverseChannel()
 }

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/websocket"
 	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 )
@@ -33,7 +34,7 @@ const (
 	agentReverseChannelTag              = "agent_reverse_channel"
 	agentReverseReconnectDelay          = 5 * time.Second
 	agentReverseMaxIncomingMessageBytes = 1024 * 1024
-	agentReverseResponseChunkBytes      = 160
+	agentReverseResponseChunkBytes      = 32 * 1024
 )
 
 type agentReverseHelloMessage struct {
@@ -59,6 +60,49 @@ type agentReverseResponseMessage struct {
 
 var agentReverseChannelRunning atomic.Bool
 var agentReverseChannelWriteLock sync.Mutex
+var agentReverseAPIPathMatcher = newAgentReverseAPIPathMatcher()
+
+func newAgentReverseAPIPathMatcher() *httprouter.Router {
+	router := httprouter.New(nil)
+	handle := func(http.ResponseWriter, *http.Request, httprouter.Params) {}
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/stats"},
+		{http.MethodGet, "/queue/stats"},
+		{http.MethodGet, "/queue/:id/stats"},
+		{http.MethodGet, "/queue/:id/_scroll"},
+		{http.MethodDelete, "/queue/:id"},
+		{http.MethodDelete, "/queue/_search"},
+		{http.MethodPut, "/queue/:id/consumer/:consumer_id/offset"},
+		{http.MethodGet, "/queue/:id/consumer/:consumer_id/offset"},
+		{http.MethodDelete, "/queue/:id/consumer/:consumer_id"},
+		{http.MethodDelete, "/queue/consumer/_search"},
+		{http.MethodGet, "/pipeline/tasks/"},
+		{http.MethodPost, "/pipeline/tasks/_search"},
+		{http.MethodPost, "/pipeline/task/:id/_start"},
+		{http.MethodPost, "/pipeline/task/:id/_stop"},
+		{http.MethodGet, "/pipeline/task/:id"},
+		{http.MethodDelete, "/pipeline/task/:id"},
+		{http.MethodGet, "/config/"},
+		{http.MethodPut, "/config/"},
+		{http.MethodGet, "/config/runtime"},
+	}
+	for _, route := range routes {
+		router.Handle(route.method, route.path, handle)
+	}
+	return router
+}
+
+func shouldServeRegisteredAPIReverse(method, rawPath string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(rawPath))
+	if err != nil || parsed.Path == "" {
+		return false
+	}
+	handle, _, _ := agentReverseAPIPathMatcher.Lookup(strings.ToUpper(method), parsed.Path)
+	return handle != nil
+}
 
 func registerAgentReverseChannel() {
 	global.RegisterBackgroundCallback(&global.BackgroundTask{
@@ -229,22 +273,25 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 	req.Header.Set("Content-Type", util.ContentTypeJson)
 	recorder := httptest.NewRecorder()
 	handler := AgentAPI{}
+	parsedPath, err := url.ParseRequestURI(requestPath)
+	if err != nil {
+		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+	}
 
-	switch requestPath {
+	switch parsedPath.Path {
 	case "/elasticsearch/node/_discovery":
 		handler.getESNodes(recorder, req, nil)
 	case "/elasticsearch/node/_info":
 		handler.getESNodeInfo(recorder, req, nil)
 	case "/elasticsearch/logs/_list":
-		handler.getElasticLogFiles(recorder, req, nil)
+		handler.getSearchLogFiles(recorder, req, nil)
 	case "/elasticsearch/logs/_read":
-		handler.readElasticLogFile(recorder, req, nil)
-	case "/stats":
-		if err := api.ServeRegisteredUIRequest(recorder, req); err != nil {
-			recorder.WriteHeader(http.StatusServiceUnavailable)
-			recorder.Write(buildAgentReverseErrorBody(http.StatusServiceUnavailable, err.Error()))
-		}
+		handler.readSearchLogFile(recorder, req, nil)
 	default:
+		if shouldServeRegisteredAPIReverse(method, requestPath) {
+			api.ServeRegisteredAPIRequest(recorder, req)
+			break
+		}
 		recorder.WriteHeader(http.StatusNotFound)
 		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))
 	}

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -239,6 +239,11 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 		handler.getElasticLogFiles(recorder, req, nil)
 	case "/elasticsearch/logs/_read":
 		handler.readElasticLogFile(recorder, req, nil)
+	case "/stats":
+		if err := api.ServeRegisteredUIRequest(recorder, req); err != nil {
+			recorder.WriteHeader(http.StatusServiceUnavailable)
+			recorder.Write(buildAgentReverseErrorBody(http.StatusServiceUnavailable, err.Error()))
+		}
 	default:
 		recorder.WriteHeader(http.StatusNotFound)
 		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -1,0 +1,298 @@
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/gorilla/websocket"
+	"infini.sh/framework/core/api"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/util"
+)
+
+const (
+	agentReverseChannelHeaderInstanceID = "X-INFINI-INSTANCE-ID"
+	agentReverseHelloCommand            = "agent_reverse_hello"
+	agentReverseRequestCommand          = "agent_reverse_request"
+	agentReverseResponseCommand         = "agent_reverse_response"
+	agentReverseChannelTag              = "agent_reverse_channel"
+	agentReverseReconnectDelay          = 5 * time.Second
+	agentReverseMaxIncomingMessageBytes = 1024 * 1024
+	agentReverseResponseChunkBytes      = 160
+)
+
+type agentReverseHelloMessage struct {
+	SessionID  string `json:"session_id"`
+	InstanceID string `json:"instance_id"`
+}
+
+type agentReverseRequestMessage struct {
+	RequestID  string `json:"request_id"`
+	InstanceID string `json:"instance_id"`
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	Body       string `json:"body,omitempty"`
+}
+
+type agentReverseResponseMessage struct {
+	RequestID  string `json:"request_id"`
+	InstanceID string `json:"instance_id"`
+	Chunk      string `json:"chunk,omitempty"`
+	Status     int    `json:"status,omitempty"`
+	Done       bool   `json:"done,omitempty"`
+}
+
+var agentReverseChannelRunning atomic.Bool
+var agentReverseChannelWriteLock sync.Mutex
+
+func registerAgentReverseChannel() {
+	global.RegisterBackgroundCallback(&global.BackgroundTask{
+		Tag:          agentReverseChannelTag,
+		Interval:     agentReverseReconnectDelay,
+		InitialDelay: agentReverseReconnectDelay,
+		Func:         ensureAgentReverseChannel,
+	})
+}
+
+func ensureAgentReverseChannel() {
+	if global.ShuttingDown() || !global.Env().SystemConfig.Configs.Managed || len(global.Env().SystemConfig.Configs.Servers) == 0 {
+		return
+	}
+	if !agentReverseChannelRunning.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer agentReverseChannelRunning.Store(false)
+		runAgentReverseChannel()
+	}()
+}
+
+func runAgentReverseChannel() {
+	for !global.ShuttingDown() {
+		err := connectAndServeAgentReverseChannel()
+		if err != nil && !global.ShuttingDown() {
+			log.Warnf("agent reverse channel disconnected: %v", err)
+		}
+		if global.ShuttingDown() {
+			return
+		}
+		time.Sleep(agentReverseReconnectDelay)
+	}
+}
+
+func connectAndServeAgentReverseChannel() error {
+	var lastErr error
+	for _, server := range global.Env().SystemConfig.Configs.Servers {
+		conn, err := dialAgentReverseChannel(server)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		defer conn.Close()
+		conn.SetReadLimit(agentReverseMaxIncomingMessageBytes)
+
+		for {
+			messageType, payload, err := conn.ReadMessage()
+			if err != nil {
+				return err
+			}
+			if messageType != websocket.TextMessage {
+				continue
+			}
+			handleAgentReverseChannelMessage(conn, payload)
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("no console server available for agent reverse channel")
+}
+
+func dialAgentReverseChannel(server string) (*websocket.Conn, error) {
+	wsURL, err := buildAgentReverseChannelURL(server)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := http.Header{}
+	headers.Set(agentReverseChannelHeaderInstanceID, global.Env().SystemConfig.NodeConfig.ID)
+	managerAuth := global.Env().SystemConfig.Configs.ManagerConfig.BasicAuth
+	if managerAuth.Username != "" {
+		token := base64.StdEncoding.EncodeToString([]byte(managerAuth.Username + ":" + managerAuth.Password.Get()))
+		headers.Set("Authorization", "Basic "+token)
+	}
+
+	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	if clientCfg := global.Env().GetHTTPClientConfig("configs", server); clientCfg != nil {
+		tlsCfg, err := api.GetClientTLSConfig(&clientCfg.TLSConfig)
+		if err != nil {
+			return nil, err
+		}
+		dialer.TLSClientConfig = tlsCfg
+	}
+	conn, _, err := dialer.Dial(wsURL, headers)
+	return conn, err
+}
+
+func buildAgentReverseChannelURL(server string) (string, error) {
+	parsed, err := url.Parse(server)
+	if err != nil {
+		return "", err
+	}
+	switch parsed.Scheme {
+	case "https":
+		parsed.Scheme = "wss"
+	default:
+		parsed.Scheme = "ws"
+	}
+	parsed.Path = path.Join(parsed.Path, "/ws")
+	return parsed.String(), nil
+}
+
+func handleAgentReverseChannelMessage(conn *websocket.Conn, payload []byte) {
+	text := string(payload)
+	parts := strings.SplitN(text, " ", 2)
+	if len(parts) != 2 {
+		return
+	}
+
+	switch parts[0] {
+	case "CONFIG":
+		if strings.HasPrefix(parts[1], "websocket-session-id:") {
+			sessionID := strings.TrimSpace(strings.TrimPrefix(parts[1], "websocket-session-id:"))
+			if sessionID != "" {
+				_ = writeAgentReverseText(conn, agentReverseHelloCommand+" "+string(util.MustToJSONBytes(agentReverseHelloMessage{
+					SessionID:  sessionID,
+					InstanceID: global.Env().SystemConfig.NodeConfig.ID,
+				})))
+			}
+		}
+	case "PRIVATE":
+		prefix := agentReverseRequestCommand + " "
+		if strings.HasPrefix(parts[1], prefix) {
+			go handleAgentReverseRequest(conn, strings.TrimPrefix(parts[1], prefix))
+		}
+	}
+}
+
+func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
+	reqMsg := agentReverseRequestMessage{}
+	if err := util.FromJSONBytes([]byte(payload), &reqMsg); err != nil {
+		body := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
+		return
+	}
+
+	body := []byte(nil)
+	if reqMsg.Body != "" {
+		decoded, err := base64.StdEncoding.DecodeString(reqMsg.Body)
+		if err != nil {
+			errBody := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+			_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusBadRequest, errBody)
+			return
+		}
+		body = decoded
+	}
+
+	status, responseBody := executeAgentReverseRequest(reqMsg.Method, reqMsg.Path, body)
+	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, status, responseBody)
+}
+
+func executeAgentReverseRequest(method, requestPath string, body []byte) (status int, responseBody []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			status = http.StatusInternalServerError
+			responseBody = buildAgentReverseErrorBody(status, fmt.Sprint(r))
+		}
+	}()
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, "http://agent"+requestPath, bodyReader)
+	req.Header.Set("Content-Type", util.ContentTypeJson)
+	recorder := httptest.NewRecorder()
+	handler := AgentAPI{}
+
+	switch requestPath {
+	case "/elasticsearch/node/_discovery":
+		handler.getESNodes(recorder, req, nil)
+	case "/elasticsearch/node/_info":
+		handler.getESNodeInfo(recorder, req, nil)
+	case "/elasticsearch/logs/_list":
+		handler.getElasticLogFiles(recorder, req, nil)
+	case "/elasticsearch/logs/_read":
+		handler.readElasticLogFile(recorder, req, nil)
+	default:
+		recorder.WriteHeader(http.StatusNotFound)
+		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))
+	}
+
+	result := recorder.Result()
+	defer result.Body.Close()
+	responseBody, _ = io.ReadAll(result.Body)
+	status = result.StatusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if len(responseBody) == 0 && status >= http.StatusBadRequest {
+		responseBody = buildAgentReverseErrorBody(status, http.StatusText(status))
+	}
+	return status, responseBody
+}
+
+func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte) error {
+	for start := 0; start < len(body); start += agentReverseResponseChunkBytes {
+		end := start + agentReverseResponseChunkBytes
+		if end > len(body) {
+			end = len(body)
+		}
+		msg := agentReverseResponseMessage{
+			RequestID:  requestID,
+			InstanceID: instanceID,
+			Chunk:      base64.StdEncoding.EncodeToString(body[start:end]),
+		}
+		if err := writeAgentReverseText(conn, agentReverseResponseCommand+" "+string(util.MustToJSONBytes(msg))); err != nil {
+			return err
+		}
+	}
+
+	doneMsg := agentReverseResponseMessage{
+		RequestID:  requestID,
+		InstanceID: instanceID,
+		Status:     status,
+		Done:       true,
+	}
+	return writeAgentReverseText(conn, agentReverseResponseCommand+" "+string(util.MustToJSONBytes(doneMsg)))
+}
+
+func writeAgentReverseText(conn *websocket.Conn, payload string) error {
+	agentReverseChannelWriteLock.Lock()
+	defer agentReverseChannelWriteLock.Unlock()
+	return conn.WriteMessage(websocket.TextMessage, []byte(payload))
+}
+
+func buildAgentReverseErrorBody(status int, reason string) []byte {
+	return util.MustToJSONBytes(util.MapStr{
+		"error": util.MapStr{
+			"reason": reason,
+		},
+		"status": status,
+	})
+}

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/websocket"
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 )
@@ -58,9 +59,19 @@ type agentReverseResponseMessage struct {
 	Done       bool   `json:"done,omitempty"`
 }
 
+type agentReverseProxyTarget struct {
+	endpoint      string
+	basePath      string
+	tlsConfig     config.TLSConfig
+	basicAuthUser string
+	basicAuthPass string
+}
+
 var agentReverseChannelRunning atomic.Bool
 var agentReverseChannelWriteLock sync.Mutex
 var agentReverseAPIPathMatcher = newAgentReverseAPIPathMatcher()
+var agentReverseAPIProxyTargetResolver = resolveAgentReverseAPIProxyTarget
+var agentReverseHTTPClientFactory = newAgentReverseHTTPClient
 
 func newAgentReverseAPIPathMatcher() *httprouter.Router {
 	router := httprouter.New(nil)
@@ -289,8 +300,7 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 		handler.readSearchLogFile(recorder, req, nil)
 	default:
 		if shouldServeRegisteredAPIReverse(method, requestPath) {
-			api.ServeRegisteredAPIRequest(recorder, req)
-			break
+			return executeAgentRegisteredAPIReverse(method, requestPath, body)
 		}
 		recorder.WriteHeader(http.StatusNotFound)
 		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))
@@ -307,6 +317,119 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 		responseBody = buildAgentReverseErrorBody(status, http.StatusText(status))
 	}
 	return status, responseBody
+}
+
+func executeAgentRegisteredAPIReverse(method, requestPath string, body []byte) (status int, responseBody []byte) {
+	target, err := agentReverseAPIProxyTargetResolver()
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+
+	proxyURL, err := buildAgentReverseProxyURL(target.endpoint, target.basePath, requestPath)
+	if err != nil {
+		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+	}
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, proxyURL, bodyReader)
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", util.ContentTypeJson)
+	}
+	if target.basicAuthUser != "" {
+		req.SetBasicAuth(target.basicAuthUser, target.basicAuthPass)
+	}
+
+	client, err := agentReverseHTTPClientFactory(target)
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+	result, err := client.Do(req)
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+	defer result.Body.Close()
+
+	responseBody, _ = io.ReadAll(result.Body)
+	status = result.StatusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if len(responseBody) == 0 && status >= http.StatusBadRequest {
+		responseBody = buildAgentReverseErrorBody(status, http.StatusText(status))
+	}
+	return status, responseBody
+}
+
+func resolveAgentReverseAPIProxyTarget() (agentReverseProxyTarget, error) {
+	apiCfg := global.Env().SystemConfig.APIConfig
+	if apiCfg.Enabled {
+		return agentReverseProxyTarget{
+			endpoint:      apiCfg.GetEndpoint(),
+			basePath:      apiCfg.BasePath,
+			tlsConfig:     apiCfg.TLSConfig,
+			basicAuthUser: apiCfg.Security.Username,
+			basicAuthPass: apiCfg.Security.Password,
+		}, nil
+	}
+
+	webCfg := global.Env().SystemConfig.WebAppConfig
+	if webCfg.Enabled && webCfg.EmbeddingAPI {
+		return agentReverseProxyTarget{
+			endpoint:  webCfg.GetEndpoint(),
+			basePath:  webCfg.BasePath,
+			tlsConfig: webCfg.TLSConfig,
+		}, nil
+	}
+	return agentReverseProxyTarget{}, fmt.Errorf("reverse channel api endpoint unavailable")
+}
+
+func buildAgentReverseProxyURL(endpoint, basePath, requestPath string) (string, error) {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(requestPath))
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(endpoint) == "" {
+		return "", fmt.Errorf("reverse channel endpoint unavailable")
+	}
+
+	fullPath := parsed.Path
+	basePath = strings.TrimSpace(basePath)
+	if basePath != "" && basePath != "/" {
+		if !strings.HasPrefix(basePath, "/") {
+			basePath = "/" + basePath
+		}
+		fullPath = strings.TrimRight(basePath, "/") + fullPath
+	}
+
+	proxyURL := strings.TrimRight(strings.TrimSpace(endpoint), "/") + fullPath
+	if parsed.RawQuery != "" {
+		proxyURL += "?" + parsed.RawQuery
+	}
+	return proxyURL, nil
+}
+
+func newAgentReverseHTTPClient(target agentReverseProxyTarget) (*http.Client, error) {
+	transport := &http.Transport{}
+	if target.tlsConfig.TLSEnabled {
+		tlsCfg := target.tlsConfig
+		tlsCfg.SkipDomainVerify = true
+		clientTLSConfig, err := api.GetClientTLSConfig(&tlsCfg)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = clientTLSConfig
+	}
+
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: transport,
+	}, nil
 }
 
 func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte) error {

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -2,7 +2,11 @@ package api
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+
+	"infini.sh/framework/core/global"
 )
 
 func TestBuildAgentReverseChannelURL(t *testing.T) {
@@ -65,5 +69,87 @@ func TestShouldServeRegisteredAPIReverse(t *testing.T) {
 				t.Fatalf("unexpected match result: %v", actual)
 			}
 		})
+	}
+}
+
+func TestExecuteAgentRegisteredAPIReverse(t *testing.T) {
+	oldResolver := agentReverseAPIProxyTargetResolver
+	oldClientFactory := agentReverseHTTPClientFactory
+	t.Cleanup(func() {
+		agentReverseAPIProxyTargetResolver = oldResolver
+		agentReverseHTTPClientFactory = oldClientFactory
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		user, password, ok := req.BasicAuth()
+		if !ok || user != "api-user" || password != "api-pass" {
+			t.Fatalf("unexpected basic auth: %v %s %s", ok, user, password)
+		}
+		if req.URL.Path != "/api/queue/stats" || req.URL.RawQuery != "size=20" {
+			t.Fatalf("unexpected proxied url: %s", req.URL.String())
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer server.Close()
+
+	agentReverseAPIProxyTargetResolver = func() (agentReverseProxyTarget, error) {
+		return agentReverseProxyTarget{
+			endpoint:      server.URL,
+			basePath:      "/api",
+			basicAuthUser: "api-user",
+			basicAuthPass: "api-pass",
+		}, nil
+	}
+	agentReverseHTTPClientFactory = func(agentReverseProxyTarget) (*http.Client, error) {
+		return server.Client(), nil
+	}
+
+	status, body := executeAgentRegisteredAPIReverse(http.MethodGet, "/queue/stats?size=20", nil)
+	if status != http.StatusAccepted {
+		t.Fatalf("unexpected status: %d", status)
+	}
+	if string(body) != "proxied" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestResolveAgentReverseAPIProxyTarget(t *testing.T) {
+	oldAPIConfig := global.Env().SystemConfig.APIConfig
+	oldWebConfig := global.Env().SystemConfig.WebAppConfig
+	t.Cleanup(func() {
+		global.Env().SystemConfig.APIConfig = oldAPIConfig
+		global.Env().SystemConfig.WebAppConfig = oldWebConfig
+	})
+
+	apiURL, _ := url.Parse("http://127.0.0.1:9000")
+	global.Env().SystemConfig.APIConfig.Enabled = true
+	global.Env().SystemConfig.APIConfig.NetworkConfig.Publish = apiURL.Host
+	global.Env().SystemConfig.APIConfig.BasePath = "/api"
+	global.Env().SystemConfig.APIConfig.Security.Username = "api-user"
+	global.Env().SystemConfig.APIConfig.Security.Password = "api-pass"
+
+	target, err := resolveAgentReverseAPIProxyTarget()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target.endpoint != "http://"+apiURL.Host {
+		t.Fatalf("unexpected endpoint: %s", target.endpoint)
+	}
+	if target.basePath != "/api" {
+		t.Fatalf("unexpected base path: %s", target.basePath)
+	}
+	if target.basicAuthUser != "api-user" || target.basicAuthPass != "api-pass" {
+		t.Fatalf("unexpected auth target: %#v", target)
+	}
+}
+
+func TestBuildAgentReverseProxyURL(t *testing.T) {
+	actual, err := buildAgentReverseProxyURL("http://127.0.0.1:9000", "/api", "/queue/stats?size=20")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actual != "http://127.0.0.1:9000/api/queue/stats?size=20" {
+		t.Fatalf("unexpected proxy url: %s", actual)
 	}
 }

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -45,3 +45,25 @@ func TestExecuteAgentReverseRequestUnknownPath(t *testing.T) {
 		t.Fatal("expected error body")
 	}
 }
+
+func TestShouldServeRegisteredAPIReverse(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method string
+		path   string
+		expect bool
+	}{
+		{name: "queue stats", method: http.MethodGet, path: "/queue/stats", expect: true},
+		{name: "task search with query", method: http.MethodGet, path: "/pipeline/tasks/?size=20", expect: true},
+		{name: "config runtime", method: http.MethodGet, path: "/config/runtime", expect: true},
+		{name: "unsupported logger path", method: http.MethodPost, path: "/setting/logger", expect: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := shouldServeRegisteredAPIReverse(tc.method, tc.path); actual != tc.expect {
+				t.Fatalf("unexpected match result: %v", actual)
+			}
+		})
+	}
+}

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestBuildAgentReverseChannelURL(t *testing.T) {
+	testCases := []struct {
+		name   string
+		server string
+		expect string
+	}{
+		{
+			name:   "http root",
+			server: "http://console.example.com",
+			expect: "ws://console.example.com/ws",
+		},
+		{
+			name:   "https base path",
+			server: "https://console.example.com/console",
+			expect: "wss://console.example.com/console/ws",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := buildAgentReverseChannelURL(tc.server)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.expect {
+				t.Fatalf("unexpected ws url, got %s want %s", actual, tc.expect)
+			}
+		})
+	}
+}
+
+func TestExecuteAgentReverseRequestUnknownPath(t *testing.T) {
+	status, body := executeAgentReverseRequest(http.MethodGet, "/not-found", nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("unexpected status: %d", status)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected error body")
+	}
+}


### PR DESCRIPTION
## Summary
- add the agent reverse-channel client loop and websocket request/response handling
- transparently proxy reverse requests for stats, queue, config, and task APIs over the local HTTP listener so normal HTTP filters stay in place
- add focused reverse-channel tests for URL building, unknown-path handling, and proxied protected API routing

## Testing
- go test ./plugin/api/... (validated with a temporary modfile pointing `infini.sh/framework` to a local framework worktree with the token and reverse-endpoint config helpers)
