### PR TITLE
feat(api): add token-authenticated protected agent routes

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -65,6 +65,8 @@ web:
     managed: $[[env.SECURITY_MANAGED_ENABLED]]
 
 agent:
+#  setup:
+#    reverse_channel_endpoint: "https://127.0.0.1:2900"
 
 metrics:
   enabled: true

--- a/agent.yml
+++ b/agent.yml
@@ -66,7 +66,7 @@ web:
 
 agent:
 #  setup:
-#    reverse_channel_endpoint: "https://127.0.0.1:2900"
+#    reverse_channel_endpoints: ["https://127.0.0.1:2900"]
 
 metrics:
   enabled: true

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -7,8 +7,10 @@ package api
 import (
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/model"
 	"infini.sh/framework/core/security"
 	"net/http"
+	"strings"
 )
 
 type AgentAPI struct {
@@ -18,24 +20,33 @@ type AgentAPI struct {
 func InitAPI() {
 	agentAPI := AgentAPI{}
 
-	// Discovery & logs — require login
-	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.requireLogin(agentAPI.getESNodes), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLogin(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLogin(agentAPI.getSearchLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLogin(agentAPI.readSearchLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	// Discovery & logs — require login or agent access token
+	api.HandleUIMethod(api.GET, "/agent/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getAgentInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.requireLoginOrAccessToken(agentAPI.getESNodes), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLoginOrAccessToken(agentAPI.getSearchLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLoginOrAccessToken(agentAPI.readSearchLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 
 	for _, route := range protectedAPIRoutes {
-		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLogin(agentAPI.proxyProtectedAPI))
+		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLoginOrAccessToken(agentAPI.proxyProtectedAPI))
 	}
 	registerAgentReverseChannel()
+}
+
+func (a AgentAPI) getAgentInfo(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	a.WriteJSON(w, model.GetInstanceInfo(), http.StatusOK)
 }
 
 func (a AgentAPI) proxyProtectedAPI(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	api.ServeRegisteredAPIRequest(w, req)
 }
 
-func (a AgentAPI) requireLogin(next httprouter.Handle) httprouter.Handle {
+func (a AgentAPI) requireLoginOrAccessToken(next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		if validateRequestAccessToken(req) {
+			next(w, req, ps)
+			return
+		}
 		if api.IsAuthEnable() {
 			user, err := security.ValidateLogin(w, req)
 			if err != nil {
@@ -47,4 +58,15 @@ func (a AgentAPI) requireLogin(next httprouter.Handle) httprouter.Handle {
 
 		next(w, req, ps)
 	}
+}
+
+func validateRequestAccessToken(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	value := strings.TrimSpace(req.Header.Get("Authorization"))
+	if !strings.HasPrefix(strings.ToLower(value), "bearer ") {
+		return false
+	}
+	return validateAgentAccessToken(strings.TrimSpace(value[7:]))
 }

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -9,6 +9,7 @@ import (
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/model"
 	"infini.sh/framework/core/security"
+	configcommon "infini.sh/framework/modules/configs/common"
 	"net/http"
 	"strings"
 )
@@ -19,6 +20,7 @@ type AgentAPI struct {
 
 func InitAPI() {
 	agentAPI := AgentAPI{}
+	_ = ensureAgentAccessToken()
 
 	// Discovery & logs — require login or agent access token
 	api.HandleUIMethod(api.GET, "/agent/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getAgentInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
@@ -31,6 +33,11 @@ func InitAPI() {
 		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLoginOrAccessToken(agentAPI.proxyProtectedAPI))
 	}
 	registerAgentReverseChannel()
+}
+
+func ensureAgentAccessToken() error {
+	_, err := configcommon.EnsureTokenInKeystore(configcommon.AgentAccessTokenKeystoreKey)
+	return err
 }
 
 func (a AgentAPI) getAgentInfo(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/model"
@@ -20,7 +21,9 @@ type AgentAPI struct {
 
 func InitAPI() {
 	agentAPI := AgentAPI{}
-	_ = ensureAgentAccessToken()
+	if err := ensureAgentAccessToken(); err != nil {
+		log.Errorf("failed to ensure agent access token: %v", err)
+	}
 
 	// Discovery & logs — require login or agent access token
 	api.HandleUIMethod(api.GET, "/agent/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getAgentInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -6,6 +6,9 @@ package api
 
 import (
 	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/security"
+	"net/http"
 )
 
 type AgentAPI struct {
@@ -16,9 +19,32 @@ func InitAPI() {
 	agentAPI := AgentAPI{}
 
 	// Discovery & logs — require login
-	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.getESNodes, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getSearchLogFiles, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readSearchLogFile, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.requireLogin(agentAPI.getESNodes), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLogin(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLogin(agentAPI.getSearchLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLogin(agentAPI.readSearchLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+
+	for _, route := range protectedAPIRoutes {
+		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLogin(agentAPI.proxyProtectedAPI))
+	}
 	registerAgentReverseChannel()
+}
+
+func (a AgentAPI) proxyProtectedAPI(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	api.ServeRegisteredAPIRequest(w, req)
+}
+
+func (a AgentAPI) requireLogin(next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		if api.IsAuthEnable() {
+			user, err := security.ValidateLogin(w, req)
+			if err != nil {
+				a.WriteError(w, err.Error(), http.StatusUnauthorized)
+				return
+			}
+			req = req.WithContext(security.AddUserToContext(req.Context(), user))
+		}
+
+		next(w, req, ps)
+	}
 }

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -31,10 +31,6 @@ func InitAPI() {
 	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLoginOrAccessToken(agentAPI.getSearchLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLoginOrAccessToken(agentAPI.readSearchLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-
-	for _, route := range protectedAPIRoutes {
-		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLoginOrAccessToken(agentAPI.proxyProtectedAPI))
-	}
 	registerAgentReverseChannel()
 }
 
@@ -45,10 +41,6 @@ func ensureAgentAccessToken() error {
 
 func (a AgentAPI) getAgentInfo(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	a.WriteJSON(w, model.GetInstanceInfo(), http.StatusOK)
-}
-
-func (a AgentAPI) proxyProtectedAPI(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	api.ServeRegisteredAPIRequest(w, req)
 }
 
 func (a AgentAPI) requireLoginOrAccessToken(next httprouter.Handle) httprouter.Handle {

--- a/plugin/api/init_test.go
+++ b/plugin/api/init_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"testing"
+
+	configcommon "infini.sh/framework/modules/configs/common"
+)
+
+func TestEnsureAgentAccessToken(t *testing.T) {
+	t.Setenv("KEYSTORE_PATH", t.TempDir())
+
+	if err := ensureAgentAccessToken(); err != nil {
+		t.Fatalf("ensure access token: %v", err)
+	}
+
+	value, err := configcommon.LoadTokenFromKeystore(configcommon.AgentAccessTokenKeystoreKey)
+	if err != nil {
+		t.Fatalf("load access token: %v", err)
+	}
+	if value == "" {
+		t.Fatal("expected access token to be initialized")
+	}
+}

--- a/plugin/api/protected_api_routes.go
+++ b/plugin/api/protected_api_routes.go
@@ -31,6 +31,8 @@ var protectedAPIRoutes = []protectedAPIRoute{
 	{http.MethodGet, "/config/"},
 	{http.MethodPut, "/config/"},
 	{http.MethodGet, "/config/runtime"},
+	{http.MethodGet, "/setting/logger"},
+	{http.MethodPost, "/setting/logger"},
 }
 
 func registerProtectedAPIRoutes(router *httprouter.Router, handle httprouter.Handle) {

--- a/plugin/api/protected_api_routes.go
+++ b/plugin/api/protected_api_routes.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"net/http"
+
+	httprouter "infini.sh/framework/core/api/router"
+)
+
+type protectedAPIRoute struct {
+	method string
+	path   string
+}
+
+var protectedAPIRoutes = []protectedAPIRoute{
+	{http.MethodGet, "/stats"},
+	{http.MethodGet, "/queue/stats"},
+	{http.MethodGet, "/queue/:id/stats"},
+	{http.MethodGet, "/queue/:id/_scroll"},
+	{http.MethodDelete, "/queue/:id"},
+	{http.MethodDelete, "/queue/_search"},
+	{http.MethodPut, "/queue/:id/consumer/:consumer_id/offset"},
+	{http.MethodGet, "/queue/:id/consumer/:consumer_id/offset"},
+	{http.MethodDelete, "/queue/:id/consumer/:consumer_id"},
+	{http.MethodDelete, "/queue/consumer/_search"},
+	{http.MethodGet, "/pipeline/tasks/"},
+	{http.MethodPost, "/pipeline/tasks/_search"},
+	{http.MethodPost, "/pipeline/task/:id/_start"},
+	{http.MethodPost, "/pipeline/task/:id/_stop"},
+	{http.MethodGet, "/pipeline/task/:id"},
+	{http.MethodDelete, "/pipeline/task/:id"},
+	{http.MethodGet, "/config/"},
+	{http.MethodPut, "/config/"},
+	{http.MethodGet, "/config/runtime"},
+}
+
+func registerProtectedAPIRoutes(router *httprouter.Router, handle httprouter.Handle) {
+	for _, route := range protectedAPIRoutes {
+		router.Handle(route.method, route.path, handle)
+	}
+}

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -45,11 +46,12 @@ type agentReverseHelloMessage struct {
 }
 
 type agentReverseRequestMessage struct {
-	RequestID  string `json:"request_id"`
-	InstanceID string `json:"instance_id"`
-	Method     string `json:"method"`
-	Path       string `json:"path"`
-	Body       string `json:"body,omitempty"`
+	RequestID   string `json:"request_id"`
+	InstanceID  string `json:"instance_id"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Body        string `json:"body,omitempty"`
+	AccessToken string `json:"access_token,omitempty"`
 }
 
 type agentReverseResponseMessage struct {
@@ -180,8 +182,14 @@ func dialAgentReverseChannel(server string) (*websocket.Conn, error) {
 
 	headers := http.Header{}
 	headers.Set(agentReverseChannelHeaderInstanceID, global.Env().SystemConfig.NodeConfig.ID)
+	managerToken, err := configcommon.LoadTokenFromKeystore(configcommon.ManagerTokenKeystoreKey)
+	if err != nil {
+		return nil, err
+	}
 	managerAuth := global.Env().SystemConfig.Configs.ManagerConfig.BasicAuth
-	if managerAuth.Username != "" {
+	if managerToken != "" {
+		headers.Set("Authorization", "Bearer "+managerToken)
+	} else if managerAuth.Username != "" {
 		token := base64.StdEncoding.EncodeToString([]byte(managerAuth.Username + ":" + managerAuth.Password.Get()))
 		headers.Set("Authorization", "Basic "+token)
 	}
@@ -246,6 +254,11 @@ func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
 		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
 		return
 	}
+	if !validateAgentAccessToken(reqMsg.AccessToken) {
+		body := buildAgentReverseErrorBody(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusUnauthorized, body)
+		return
+	}
 
 	body := []byte(nil)
 	if reqMsg.Body != "" {
@@ -284,6 +297,8 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 	}
 
 	switch parsedPath.Path {
+	case "/agent/_info":
+		handler.getAgentInfo(recorder, req, nil)
 	case "/elasticsearch/node/_discovery":
 		handler.getESNodes(recorder, req, nil)
 	case "/elasticsearch/node/_info":
@@ -464,4 +479,12 @@ func buildAgentReverseErrorBody(status int, reason string) []byte {
 		},
 		"status": status,
 	})
+}
+
+func validateAgentAccessToken(tokenValue string) bool {
+	expected, err := configcommon.LoadTokenFromKeystore(configcommon.AgentAccessTokenKeystoreKey)
+	if err != nil || expected == "" || tokenValue == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(tokenValue)) == 1
 }

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -25,6 +25,7 @@ import (
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
+	configcommon "infini.sh/framework/modules/configs/common"
 )
 
 const (
@@ -76,33 +77,7 @@ var agentReverseHTTPClientFactory = newAgentReverseHTTPClient
 func newAgentReverseAPIPathMatcher() *httprouter.Router {
 	router := httprouter.New(nil)
 	handle := func(http.ResponseWriter, *http.Request, httprouter.Params) {}
-	routes := []struct {
-		method string
-		path   string
-	}{
-		{http.MethodGet, "/stats"},
-		{http.MethodGet, "/queue/stats"},
-		{http.MethodGet, "/queue/:id/stats"},
-		{http.MethodGet, "/queue/:id/_scroll"},
-		{http.MethodDelete, "/queue/:id"},
-		{http.MethodDelete, "/queue/_search"},
-		{http.MethodPut, "/queue/:id/consumer/:consumer_id/offset"},
-		{http.MethodGet, "/queue/:id/consumer/:consumer_id/offset"},
-		{http.MethodDelete, "/queue/:id/consumer/:consumer_id"},
-		{http.MethodDelete, "/queue/consumer/_search"},
-		{http.MethodGet, "/pipeline/tasks/"},
-		{http.MethodPost, "/pipeline/tasks/_search"},
-		{http.MethodPost, "/pipeline/task/:id/_start"},
-		{http.MethodPost, "/pipeline/task/:id/_stop"},
-		{http.MethodGet, "/pipeline/task/:id"},
-		{http.MethodDelete, "/pipeline/task/:id"},
-		{http.MethodGet, "/config/"},
-		{http.MethodPut, "/config/"},
-		{http.MethodGet, "/config/runtime"},
-	}
-	for _, route := range routes {
-		router.Handle(route.method, route.path, handle)
-	}
+	registerProtectedAPIRoutes(router, handle)
 	return router
 }
 
@@ -125,7 +100,7 @@ func registerAgentReverseChannel() {
 }
 
 func ensureAgentReverseChannel() {
-	if global.ShuttingDown() || !global.Env().SystemConfig.Configs.Managed || len(global.Env().SystemConfig.Configs.Servers) == 0 {
+	if global.ShuttingDown() || !global.Env().SystemConfig.Configs.Managed || len(getAgentReverseChannelServers()) == 0 {
 		return
 	}
 	if !agentReverseChannelRunning.CompareAndSwap(false, true) {
@@ -152,7 +127,7 @@ func runAgentReverseChannel() {
 
 func connectAndServeAgentReverseChannel() error {
 	var lastErr error
-	for _, server := range global.Env().SystemConfig.Configs.Servers {
+	for _, server := range getAgentReverseChannelServers() {
 		conn, err := dialAgentReverseChannel(server)
 		if err != nil {
 			lastErr = err
@@ -176,6 +151,25 @@ func connectAndServeAgentReverseChannel() error {
 		return lastErr
 	}
 	return fmt.Errorf("no console server available for agent reverse channel")
+}
+
+func getAgentReverseChannelServers() []string {
+	agentCfg := configcommon.GetAgentConfig()
+	if agentCfg != nil && agentCfg.Setup != nil {
+		if endpoint := strings.TrimSpace(agentCfg.Setup.ReverseChannelEndpoint); endpoint != "" {
+			return []string{endpoint}
+		}
+	}
+
+	servers := make([]string, 0, len(global.Env().SystemConfig.Configs.Servers))
+	for _, server := range global.Env().SystemConfig.Configs.Servers {
+		server = strings.TrimSpace(server)
+		if server == "" {
+			continue
+		}
+		servers = append(servers, server)
+	}
+	return servers
 }
 
 func dialAgentReverseChannel(server string) (*websocket.Conn, error) {

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -158,8 +158,16 @@ func connectAndServeAgentReverseChannel() error {
 func getAgentReverseChannelServers() []string {
 	agentCfg := configcommon.GetAgentConfig()
 	if agentCfg != nil && agentCfg.Setup != nil {
-		if endpoint := strings.TrimSpace(agentCfg.Setup.ReverseChannelEndpoint); endpoint != "" {
-			return []string{endpoint}
+		servers := make([]string, 0, len(agentCfg.Setup.ReverseChannelEndpoints))
+		for _, endpoint := range agentCfg.Setup.ReverseChannelEndpoints {
+			endpoint = strings.TrimSpace(endpoint)
+			if endpoint == "" {
+				continue
+			}
+			servers = append(servers, endpoint)
+		}
+		if len(servers) > 0 {
+			return servers
 		}
 	}
 

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -60,7 +60,7 @@ func TestShouldServeRegisteredAPIReverse(t *testing.T) {
 		{name: "queue stats", method: http.MethodGet, path: "/queue/stats", expect: true},
 		{name: "task search with query", method: http.MethodGet, path: "/pipeline/tasks/?size=20", expect: true},
 		{name: "config runtime", method: http.MethodGet, path: "/config/runtime", expect: true},
-		{name: "unsupported logger path", method: http.MethodPost, path: "/setting/logger", expect: false},
+		{name: "logger setting", method: http.MethodPost, path: "/setting/logger", expect: true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- add `/agent/_info` plus login-or-access-token access for discovery and log APIs without reopening protected backend APIs on the UI listener
- bootstrap and validate the agent access token locally, use bearer manager auth for reverse-channel connect when present, and include the logger settings route in the protected reverse allowlist
- adapt reverse channel endpoint config to `reverse_channel_endpoints` so the agent branch matches framework multi-endpoint config support

## Dependencies
- agent#76
- framework#342
- framework#346

## Validation
- go test -mod=mod -modfile=.copilot-test.mod ./plugin/api/... with a temporary local framework worktree stacking #342 and #346
