### PR TITLE
feat(api): support buffered agent log reads

### DIFF
--- a/plugin/api/log.go
+++ b/plugin/api/log.go
@@ -5,6 +5,8 @@
 package api
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,12 +17,21 @@ import (
 	"strings"
 
 	log "github.com/cihub/seelog"
-	"infini.sh/agent/lib/reader/linenumber"
 	agent_util "infini.sh/agent/lib/util"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 )
+
+const (
+	logReadBufferSize = 64 * 1024
+	maxReadLines      = 200
+	maxCountRowsBytes = 8 * 1024 * 1024
+)
+
+func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	handler.getSearchLogFiles(w, req, params)
+}
 
 func (handler *AgentAPI) getSearchLogFiles(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 	reqBody := GetSearchLogFilesReq{}
@@ -30,6 +41,7 @@ func (handler *AgentAPI) getSearchLogFiles(w http.ResponseWriter, req *http.Requ
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	logsPaths := normalizeJSONLogsPaths(reqBody.LogsPath)
 	if len(logsPaths) == 0 {
 		handler.WriteError(w, "miss param logs_path", http.StatusInternalServerError)
@@ -43,36 +55,50 @@ func (handler *AgentAPI) getSearchLogFiles(w http.ResponseWriter, req *http.Requ
 		log.Error(errMsg)
 		errors = append(errors, errMsg)
 	}
+
 	for _, logsPath := range logsPaths {
-		fileInfos, err := os.ReadDir(logsPath)
+		resolvedLogsPath, err := resolveLogsDirectory(logsPath)
 		if err != nil {
-			appendError("failed to read search logs directory [%s]: %v", logsPath, err)
+			appendError("failed to resolve search logs directory [%s]: %v", logsPath, err)
 			continue
 		}
+
+		fileInfos, err := os.ReadDir(resolvedLogsPath)
+		if err != nil {
+			appendError("failed to read search logs directory [%s]: %v", resolvedLogsPath, err)
+			continue
+		}
+
 		for _, info := range fileInfos {
 			if info.IsDir() {
 				continue
 			}
 			fInfo, err := info.Info()
 			if err != nil {
-				appendError("failed to read file info in logs directory [%s], file=[%s]: %v", logsPath, info.Name(), err)
+				appendError("failed to read file info in logs directory [%s], file=[%s]: %v", resolvedLogsPath, info.Name(), err)
 				continue
 			}
-			filePath := path.Join(logsPath, info.Name())
-			totalRows, err := agent_util.CountFileRows(filePath)
-			if err != nil {
-				appendError("failed to count rows for log file [%s]: %v", filePath, err)
-				continue
+			filePath := path.Join(resolvedLogsPath, info.Name())
+			fileItem := util.MapStr{
+				"name":             fInfo.Name(),
+				"logs_path":        resolvedLogsPath,
+				"size_in_bytes":    fInfo.Size(),
+				"modify_time":      fInfo.ModTime(),
+				"total_rows_known": false,
 			}
-			files = append(files, util.MapStr{
-				"name":          fInfo.Name(),
-				"logs_path":     logsPath,
-				"size_in_bytes": fInfo.Size(),
-				"modify_time":   fInfo.ModTime(),
-				"total_rows":    totalRows,
-			})
+			if shouldCountLogRows(fInfo.Size()) {
+				totalRows, err := agent_util.CountFileRows(filePath)
+				if err != nil {
+					appendError("failed to count rows for log file [%s]: %v", filePath, err)
+					continue
+				}
+				fileItem["total_rows"] = totalRows
+				fileItem["total_rows_known"] = true
+			}
+			files = append(files, fileItem)
 		}
 	}
+
 	if len(errors) > 0 {
 		handler.WriteJSON(w, util.MapStr{
 			"result":  files,
@@ -88,6 +114,10 @@ func (handler *AgentAPI) getSearchLogFiles(w http.ResponseWriter, req *http.Requ
 	}, http.StatusOK)
 }
 
+func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	handler.readSearchLogFile(w, req, params)
+}
+
 func (handler *AgentAPI) readSearchLogFile(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 	reqBody := ReadSearchLogFileReq{}
 	err := handler.DecodeJSON(req, &reqBody)
@@ -97,17 +127,30 @@ func (handler *AgentAPI) readSearchLogFile(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	logFilePath, err := safeJoinLogsFile(reqBody.LogsPath, reqBody.FileName)
+	reqBody.LogsPath = strings.TrimSpace(reqBody.LogsPath)
+	if reqBody.LogsPath == "" {
+		handler.WriteError(w, "miss param logs_path", http.StatusInternalServerError)
+		return
+	}
+
+	reqBody.LogsPath, err = resolveLogsDirectory(reqBody.LogsPath)
+	if err != nil {
+		log.Error(err)
+		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	logFilePath, err := resolveLogFilePath(reqBody.LogsPath, reqBody.FileName)
 	if err != nil {
 		log.Errorf("invalid search log file request, logs_path=[%s], file_name=[%s]: %v", reqBody.LogsPath, reqBody.FileName, err)
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	if reqBody.StartLineNumber < 0 {
 		reqBody.StartLineNumber = 0
 	}
 	if strings.HasSuffix(reqBody.FileName, ".gz") {
-		// read gzip log file, and then unpack it to tmp file
 		tmpFilePath := filepath.Join(os.TempDir(), "agent", strings.TrimSuffix(reqBody.FileName, ".gz"))
 		if !util.FileExists(tmpFilePath) {
 			fileDir := filepath.Dir(tmpFilePath)
@@ -128,13 +171,41 @@ func (handler *AgentAPI) readSearchLogFile(w http.ResponseWriter, req *http.Requ
 		}
 		logFilePath = tmpFilePath
 	}
-	r, err := linenumber.NewLinePlainTextReader(logFilePath, reqBody.StartLineNumber, io.SeekStart)
+	var msgs []util.MapStr
+	var isEOF bool
+	if reqBody.TailLines > 0 {
+		msgs, err = readSearchLogTailLines(logFilePath, reqBody.TailLines)
+		isEOF = true
+	} else {
+		msgs, isEOF, err = readSearchLogLines(logFilePath, reqBody.StartLineNumber, reqBody.Offset, reqBody.Lines)
+	}
 	if err != nil {
-		log.Errorf("failed to open search log file [%s], start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
-		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
+		log.Errorf("failed to read search log file [%s] at start_line_number=[%d], offset=[%d], tail_lines=[%d]: %v", logFilePath, reqBody.StartLineNumber, reqBody.Offset, reqBody.TailLines, err)
+		handler.WriteError(w, fmt.Sprintf("read logs error: %v", err), http.StatusInternalServerError)
 		return
 	}
+	handler.WriteJSON(w, util.MapStr{
+		"result":  msgs,
+		"success": true,
+		"EOF":     isEOF,
+	}, http.StatusOK)
+}
 
+func readSearchLogLines(filePath string, startLineNumber int64, offset int64, lines int) ([]util.MapStr, bool, error) {
+	if lines <= 0 {
+		lines = 50
+	}
+	if lines > maxReadLines {
+		lines = maxReadLines
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, false, err
+	}
 	defer func() {
 		if !global.Env().IsDebug {
 			if r := recover(); r != nil {
@@ -150,45 +221,235 @@ func (handler *AgentAPI) readSearchLogFile(w http.ResponseWriter, req *http.Requ
 				log.Error("error on exit disk_queue,", v)
 			}
 		}
-		if r != nil {
-			r.Close()
-		}
+		file.Close()
 	}()
 
-	var msgs []util.MapStr
+	currentOffset := int64(0)
+	currentLineNumber := int64(1)
+	lineNumbersKnown := true
+
+	if offset == 0 && startLineNumber < 1 {
+		startLineNumber = 1
+	}
+
+	if offset > 0 {
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
+			return nil, false, err
+		}
+		currentOffset = offset
+		if startLineNumber > 0 {
+			currentLineNumber = startLineNumber
+		} else {
+			currentLineNumber = 0
+			lineNumbersKnown = false
+		}
+	} else {
+		currentLineNumber = startLineNumber
+	}
+
+	reader := bufio.NewReaderSize(file, logReadBufferSize)
+	result := make([]util.MapStr, 0, lines)
 	isEOF := false
-	for i := 0; i < reqBody.Lines; i++ {
-		msg, err := r.Next()
-		if err != nil {
+
+	for len(result) < lines {
+		rawLine, err := reader.ReadBytes('\n')
+		if err != nil && err != io.EOF {
+			return result, false, err
+		}
+		if len(rawLine) == 0 {
 			if err == io.EOF {
 				isEOF = true
-				break
-			} else {
-				log.Errorf("failed to read search log file [%s] at start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
-				handler.WriteError(w, fmt.Sprintf("read logs error: %v", err), http.StatusInternalServerError)
-				return
 			}
+			break
 		}
-		msgs = append(msgs, util.MapStr{
-			"content":     string(msg.Content),
-			"bytes":       msg.Bytes,
-			"offset":      msg.Offset,
-			"line_number": coverLineNumbers(msg.LineNumbers),
-		})
+
+		currentOffset += int64(len(rawLine))
+		lineContent := trimLogLineEnding(rawLine)
+
+		if offset > 0 {
+			line := util.MapStr{
+				"content": string(lineContent),
+				"bytes":   len(rawLine),
+				"offset":  currentOffset,
+			}
+			if lineNumbersKnown {
+				line["line_number"] = currentLineNumber
+				currentLineNumber++
+			}
+			result = append(result, line)
+		} else {
+			if currentLineNumber >= startLineNumber {
+				line := util.MapStr{
+					"content": string(lineContent),
+					"bytes":   len(rawLine),
+					"offset":  currentOffset,
+				}
+				if lineNumbersKnown {
+					line["line_number"] = currentLineNumber
+				}
+				result = append(result, line)
+			}
+			currentLineNumber++
+		}
+
+		if err == io.EOF {
+			isEOF = true
+			break
+		}
 	}
-	handler.WriteJSON(w, util.MapStr{
-		"result":  msgs,
-		"success": true,
-		"EOF":     isEOF,
-	}, http.StatusOK)
+
+	return result, isEOF, nil
 }
 
-func coverLineNumbers(numbers []int64) interface{} {
-	if len(numbers) == 1 {
-		return numbers[0]
-	} else {
-		return numbers
+func readSearchLogTailLines(filePath string, lines int) ([]util.MapStr, error) {
+	if lines <= 0 {
+		lines = 50
 	}
+	if lines > maxReadLines {
+		lines = maxReadLines
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size() == 0 {
+		return []util.MapStr{}, nil
+	}
+
+	windowStart, windowBytes, err := locateTailWindow(file, stat.Size(), lines)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bufio.NewReaderSize(bytes.NewReader(windowBytes), logReadBufferSize)
+	currentOffset := windowStart
+	result := make([]util.MapStr, 0, lines)
+
+	for len(result) < lines {
+		rawLine, err := reader.ReadBytes('\n')
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if len(rawLine) == 0 {
+			break
+		}
+
+		currentOffset += int64(len(rawLine))
+		result = append(result, util.MapStr{
+			"content": string(trimLogLineEnding(rawLine)),
+			"bytes":   len(rawLine),
+			"offset":  currentOffset,
+		})
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func locateTailWindow(file *os.File, fileSize int64, lines int) (int64, []byte, error) {
+	position := fileSize
+	window := make([]byte, 0)
+	newlineCount := 0
+
+	for position > 0 && newlineCount <= lines {
+		chunkSize := int64(logReadBufferSize)
+		if position < chunkSize {
+			chunkSize = position
+		}
+		position -= chunkSize
+
+		chunk := make([]byte, chunkSize)
+		if _, err := file.ReadAt(chunk, position); err != nil && err != io.EOF {
+			return 0, nil, err
+		}
+		window = append(chunk, window...)
+		newlineCount += bytes.Count(chunk, []byte{'\n'})
+	}
+
+	startIndex := findTailStartIndex(window, lines)
+	return position + int64(startIndex), window[startIndex:], nil
+}
+
+func findTailStartIndex(window []byte, lines int) int {
+	if len(window) == 0 || lines <= 0 {
+		return 0
+	}
+
+	idx := len(window) - 1
+	if window[idx] == '\n' {
+		idx--
+	}
+
+	newlineCount := 0
+	for ; idx >= 0; idx-- {
+		if window[idx] != '\n' {
+			continue
+		}
+		newlineCount++
+		if newlineCount == lines {
+			return idx + 1
+		}
+	}
+	return 0
+}
+
+func shouldCountLogRows(fileSize int64) bool {
+	return fileSize >= 0 && fileSize <= maxCountRowsBytes
+}
+
+func trimLogLineEnding(rawLine []byte) []byte {
+	return bytes.TrimRight(rawLine, "\r\n")
+}
+
+func resolveLogsDirectory(logsPath string) (string, error) {
+	expanded, err := agent_util.ExpandHomeDir(logsPath)
+	if err != nil {
+		return "", err
+	}
+	resolved := filepath.Clean(expanded)
+	if resolved == "" {
+		return "", fmt.Errorf("invalid logs_path")
+	}
+	if realPath, err := filepath.EvalSymlinks(resolved); err == nil {
+		resolved = realPath
+	}
+	stat, err := os.Stat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if !stat.IsDir() {
+		return "", fmt.Errorf("logs_path is not a directory: %s", logsPath)
+	}
+	return resolved, nil
+}
+
+func resolveLogFilePath(logsPath, fileName string) (string, error) {
+	logFilePath, err := safeJoinLogsFile(logsPath, fileName)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(logFilePath)
+	if err != nil {
+		return "", err
+	}
+	relativePath, err := filepath.Rel(logsPath, resolved)
+	if err != nil {
+		return "", err
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid file_name: %s", fileName)
+	}
+	return resolved, nil
 }
 
 func normalizeJSONLogsPaths(raw interface{}) []string {
@@ -236,9 +497,7 @@ func safeJoinLogsFile(logsPath, fileName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	logsPath = expanded
-
-	basePath := filepath.Clean(logsPath)
+	basePath := filepath.Clean(expanded)
 	fullPath := filepath.Clean(filepath.Join(basePath, fileName))
 	rel, err := filepath.Rel(basePath, fullPath)
 	if err != nil {

--- a/plugin/api/log_test.go
+++ b/plugin/api/log_test.go
@@ -1,6 +1,10 @@
 package api
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestNormalizeJSONLogsPathsSupportsStringAndArray(t *testing.T) {
 	paths := normalizeJSONLogsPaths("/var/log/elasticsearch")
@@ -22,5 +26,97 @@ func TestSafeJoinLogsFileRejectsTraversal(t *testing.T) {
 
 	if _, err := safeJoinLogsFile("/var/log/elasticsearch", "../server.log"); err == nil {
 		t.Fatal("expected traversal to be rejected")
+	}
+}
+
+func TestReadSearchLogLinesUsesRealOffset(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "server.log")
+	content := "first\r\nsecond\r\nthird"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp log file: %v", err)
+	}
+
+	lines, isEOF, err := readSearchLogLines(filePath, 1, 0, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isEOF {
+		t.Fatal("expected more content after first page")
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %#v", lines)
+	}
+	if lines[0]["offset"] != int64(7) || lines[1]["offset"] != int64(15) {
+		t.Fatalf("unexpected offsets: %#v", lines)
+	}
+
+	lines, isEOF, err = readSearchLogLines(filePath, 3, lines[1]["offset"].(int64), 2)
+	if err != nil {
+		t.Fatalf("unexpected error on second page: %v", err)
+	}
+	if !isEOF {
+		t.Fatal("expected EOF on second page")
+	}
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %#v", lines)
+	}
+	if lines[0]["line_number"] != int64(3) || lines[0]["content"] != "third" {
+		t.Fatalf("unexpected second page data: %#v", lines[0])
+	}
+}
+
+func TestReadSearchLogLinesKeepsLineNumbersUnknownAfterTailMode(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "server.log")
+	content := "first\nsecond\nthird\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp log file: %v", err)
+	}
+
+	lines, _, err := readSearchLogLines(filePath, 0, 6, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %#v", lines)
+	}
+	if _, ok := lines[0]["line_number"]; ok {
+		t.Fatalf("line number should stay unknown after offset-only reads: %#v", lines[0])
+	}
+}
+
+func TestReadSearchLogTailLinesReturnsLatestOffsets(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "server.log")
+	content := "first\nsecond\nthird\nfourth\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp log file: %v", err)
+	}
+
+	lines, err := readSearchLogTailLines(filePath, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %#v", lines)
+	}
+	if lines[0]["content"] != "third" || lines[1]["content"] != "fourth" {
+		t.Fatalf("unexpected tail lines: %#v", lines)
+	}
+	if lines[0]["offset"] != int64(19) || lines[1]["offset"] != int64(26) {
+		t.Fatalf("unexpected tail offsets: %#v", lines)
+	}
+	if _, ok := lines[0]["line_number"]; ok {
+		t.Fatalf("tail reads should not claim absolute line numbers: %#v", lines[0])
+	}
+}
+
+func TestShouldCountLogRows(t *testing.T) {
+	if !shouldCountLogRows(maxCountRowsBytes) {
+		t.Fatal("expected row counts for small files")
+	}
+	if shouldCountLogRows(maxCountRowsBytes + 1) {
+		t.Fatal("expected row counts to be skipped for large files")
 	}
 }

--- a/plugin/api/model.go
+++ b/plugin/api/model.go
@@ -14,4 +14,5 @@ type ReadSearchLogFileReq struct {
 	Offset          int64  `json:"offset"`
 	Lines           int    `json:"lines"`
 	StartLineNumber int64  `json:"start_line_number"`
+	TailLines       int    `json:"tail_lines"`
 }


### PR DESCRIPTION
## Summary
- add safer multi-path agent log directory resolution including home expansion, row-count skipping for large files, and explicit `total_rows_known` reporting
- support buffered log pagination and tail reads with offset-aware responses, including gzip reads and traversal-safe file resolution
- extend plugin/api log tests and request models for `offset` and `tail_lines` based reads

## Dependencies
- agent#77

## Validation
- GOWORK=off go test -mod=mod -modfile=.copilot-test.mod ./plugin/api/... using a temporary local framework worktree stacking framework#342 and framework#346
