### PR TITLE
feat(api): adopt framework reverse protocol helpers

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -49,7 +49,7 @@ api:
   enabled: false
 
 web:
-  embedding_api: true
+  embedding_api: false
   enabled: true
   network:
     binding: $[[env.WEB_BINDING]]
@@ -65,6 +65,8 @@ web:
     managed: $[[env.SECURITY_MANAGED_ENABLED]]
 
 agent:
+#  setup:
+#    reverse_channel_endpoint: "https://127.0.0.1:2900"
 
 metrics:
   enabled: true

--- a/agent.yml
+++ b/agent.yml
@@ -49,7 +49,7 @@ api:
   enabled: false
 
 web:
-  embedding_api: false
+  embedding_api: true
   enabled: true
   network:
     binding: $[[env.WEB_BINDING]]

--- a/agent.yml
+++ b/agent.yml
@@ -66,7 +66,7 @@ web:
 
 agent:
 #  setup:
-#    reverse_channel_endpoint: "https://127.0.0.1:2900"
+#    reverse_channel_endpoints: ["https://127.0.0.1:2900"]
 
 metrics:
   enabled: true

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -9,6 +9,7 @@ import (
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/model"
 	"infini.sh/framework/core/security"
+	configcommon "infini.sh/framework/modules/configs/common"
 	"net/http"
 	"strings"
 )
@@ -19,6 +20,7 @@ type AgentAPI struct {
 
 func InitAPI() {
 	agentAPI := AgentAPI{}
+	_ = ensureAgentAccessToken()
 
 	// Discovery & logs — require login or agent access token
 	api.HandleUIMethod(api.GET, "/agent/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getAgentInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
@@ -31,6 +33,11 @@ func InitAPI() {
 		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLoginOrAccessToken(agentAPI.proxyProtectedAPI))
 	}
 	registerAgentReverseChannel()
+}
+
+func ensureAgentAccessToken() error {
+	_, err := configcommon.EnsureTokenInKeystore(configcommon.AgentAccessTokenKeystoreKey)
+	return err
 }
 
 func (a AgentAPI) getAgentInfo(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -20,4 +20,5 @@ func InitAPI() {
 	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	registerAgentReverseChannel()
 }

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -6,6 +6,9 @@ package api
 
 import (
 	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/security"
+	"net/http"
 )
 
 type AgentAPI struct {
@@ -16,9 +19,32 @@ func InitAPI() {
 	agentAPI := AgentAPI{}
 
 	// Discovery & logs — require login
-	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.getESNodes, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.getESNodeInfo, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile, api.RequireLogin(), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.requireLogin(agentAPI.getESNodes), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLogin(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLogin(agentAPI.getElasticLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLogin(agentAPI.readElasticLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+
+	for _, route := range protectedAPIRoutes {
+		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLogin(agentAPI.proxyProtectedAPI))
+	}
 	registerAgentReverseChannel()
+}
+
+func (a AgentAPI) proxyProtectedAPI(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	api.ServeRegisteredAPIRequest(w, req)
+}
+
+func (a AgentAPI) requireLogin(next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		if api.IsAuthEnable() {
+			user, err := security.ValidateLogin(w, req)
+			if err != nil {
+				a.WriteError(w, err.Error(), http.StatusUnauthorized)
+				return
+			}
+			req = req.WithContext(security.AddUserToContext(req.Context(), user))
+		}
+
+		next(w, req, ps)
+	}
 }

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -7,8 +7,10 @@ package api
 import (
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/model"
 	"infini.sh/framework/core/security"
 	"net/http"
+	"strings"
 )
 
 type AgentAPI struct {
@@ -18,24 +20,33 @@ type AgentAPI struct {
 func InitAPI() {
 	agentAPI := AgentAPI{}
 
-	// Discovery & logs — require login
-	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.requireLogin(agentAPI.getESNodes), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLogin(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLogin(agentAPI.getElasticLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLogin(agentAPI.readElasticLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	// Discovery & logs — require login or agent access token
+	api.HandleUIMethod(api.GET, "/agent/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getAgentInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.GET, "/elasticsearch/node/_discovery", agentAPI.requireLoginOrAccessToken(agentAPI.getESNodes), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLoginOrAccessToken(agentAPI.getElasticLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
+	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLoginOrAccessToken(agentAPI.readElasticLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 
 	for _, route := range protectedAPIRoutes {
-		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLogin(agentAPI.proxyProtectedAPI))
+		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLoginOrAccessToken(agentAPI.proxyProtectedAPI))
 	}
 	registerAgentReverseChannel()
+}
+
+func (a AgentAPI) getAgentInfo(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	a.WriteJSON(w, model.GetInstanceInfo(), http.StatusOK)
 }
 
 func (a AgentAPI) proxyProtectedAPI(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	api.ServeRegisteredAPIRequest(w, req)
 }
 
-func (a AgentAPI) requireLogin(next httprouter.Handle) httprouter.Handle {
+func (a AgentAPI) requireLoginOrAccessToken(next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		if validateRequestAccessToken(req) {
+			next(w, req, ps)
+			return
+		}
 		if api.IsAuthEnable() {
 			user, err := security.ValidateLogin(w, req)
 			if err != nil {
@@ -47,4 +58,15 @@ func (a AgentAPI) requireLogin(next httprouter.Handle) httprouter.Handle {
 
 		next(w, req, ps)
 	}
+}
+
+func validateRequestAccessToken(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	value := strings.TrimSpace(req.Header.Get("Authorization"))
+	if !strings.HasPrefix(strings.ToLower(value), "bearer ") {
+		return false
+	}
+	return validateAgentAccessToken(strings.TrimSpace(value[7:]))
 }

--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/model"
@@ -20,7 +21,9 @@ type AgentAPI struct {
 
 func InitAPI() {
 	agentAPI := AgentAPI{}
-	_ = ensureAgentAccessToken()
+	if err := ensureAgentAccessToken(); err != nil {
+		log.Errorf("failed to ensure agent access token: %v", err)
+	}
 
 	// Discovery & logs — require login or agent access token
 	api.HandleUIMethod(api.GET, "/agent/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getAgentInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
@@ -28,10 +31,6 @@ func InitAPI() {
 	api.HandleUIMethod(api.POST, "/elasticsearch/node/_info", agentAPI.requireLoginOrAccessToken(agentAPI.getESNodeInfo), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_list", agentAPI.requireLoginOrAccessToken(agentAPI.getElasticLogFiles), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
 	api.HandleUIMethod(api.POST, "/elasticsearch/logs/_read", agentAPI.requireLoginOrAccessToken(agentAPI.readElasticLogFile), api.AllowOPTIONSS(), api.Feature(api.FeatureCORS))
-
-	for _, route := range protectedAPIRoutes {
-		api.HandleUIMethod(api.Method(route.method), route.path, agentAPI.requireLoginOrAccessToken(agentAPI.proxyProtectedAPI))
-	}
 	registerAgentReverseChannel()
 }
 
@@ -42,10 +41,6 @@ func ensureAgentAccessToken() error {
 
 func (a AgentAPI) getAgentInfo(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	a.WriteJSON(w, model.GetInstanceInfo(), http.StatusOK)
-}
-
-func (a AgentAPI) proxyProtectedAPI(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	api.ServeRegisteredAPIRequest(w, req)
 }
 
 func (a AgentAPI) requireLoginOrAccessToken(next httprouter.Handle) httprouter.Handle {

--- a/plugin/api/init_test.go
+++ b/plugin/api/init_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"testing"
+
+	configcommon "infini.sh/framework/modules/configs/common"
+)
+
+func TestEnsureAgentAccessToken(t *testing.T) {
+	t.Setenv("KEYSTORE_PATH", t.TempDir())
+
+	if err := ensureAgentAccessToken(); err != nil {
+		t.Fatalf("ensure access token: %v", err)
+	}
+
+	value, err := configcommon.LoadTokenFromKeystore(configcommon.AgentAccessTokenKeystoreKey)
+	if err != nil {
+		t.Fatalf("load access token: %v", err)
+	}
+	if value == "" {
+		t.Fatal("expected access token to be initialized")
+	}
+}

--- a/plugin/api/log.go
+++ b/plugin/api/log.go
@@ -24,6 +24,7 @@ import (
 
 func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 	reqBody := GetElasticLogFilesReq{}
+	var err error
 	handler.DecodeJSON(req, &reqBody)
 	reqBody.LogsPath = strings.TrimSpace(reqBody.LogsPath)
 	if reqBody.LogsPath == "" {
@@ -31,13 +32,12 @@ func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Req
 		return
 	}
 
-	expanded, err := agent_util.ExpandHomeDir(reqBody.LogsPath)
+	reqBody.LogsPath, err = resolveLogsDirectory(reqBody.LogsPath)
 	if err != nil {
 		log.Error(err)
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	reqBody.LogsPath = expanded
 
 	fileInfos, err := os.ReadDir(reqBody.LogsPath)
 	if err != nil {
@@ -90,15 +90,18 @@ func (handler *AgentAPI) readElasticLogFile(w http.ResponseWriter, req *http.Req
 		return
 	}
 
-	expanded, err := agent_util.ExpandHomeDir(reqBody.LogsPath)
+	reqBody.LogsPath, err = resolveLogsDirectory(reqBody.LogsPath)
 	if err != nil {
 		log.Error(err)
 		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	reqBody.LogsPath = expanded
-
-	logFilePath := filepath.Join(reqBody.LogsPath, reqBody.FileName)
+	logFilePath, err := resolveLogFilePath(reqBody.LogsPath, reqBody.FileName)
+	if err != nil {
+		log.Error(err)
+		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	if reqBody.StartLineNumber < 0 {
 		reqBody.StartLineNumber = 0
 	}
@@ -185,4 +188,49 @@ func coverLineNumbers(numbers []int64) interface{} {
 	} else {
 		return numbers
 	}
+}
+
+func resolveLogsDirectory(logsPath string) (string, error) {
+	expanded, err := agent_util.ExpandHomeDir(logsPath)
+	if err != nil {
+		return "", err
+	}
+	resolved := filepath.Clean(expanded)
+	if resolved == "" {
+		return "", fmt.Errorf("invalid logs_path")
+	}
+	if realPath, err := filepath.EvalSymlinks(resolved); err == nil {
+		resolved = realPath
+	}
+	stat, err := os.Stat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if !stat.IsDir() {
+		return "", fmt.Errorf("logs_path is not a directory: %s", logsPath)
+	}
+	return resolved, nil
+}
+
+func resolveLogFilePath(logsPath, fileName string) (string, error) {
+	fileName = strings.TrimSpace(fileName)
+	if fileName == "" {
+		return "", fmt.Errorf("miss param file_name")
+	}
+	if fileName != filepath.Base(fileName) {
+		return "", fmt.Errorf("invalid file_name: %s", fileName)
+	}
+	logFilePath := filepath.Join(logsPath, fileName)
+	resolved, err := filepath.EvalSymlinks(logFilePath)
+	if err != nil {
+		return "", err
+	}
+	relativePath, err := filepath.Rel(logsPath, resolved)
+	if err != nil {
+		return "", err
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid file_name: %s", fileName)
+	}
+	return resolved, nil
 }

--- a/plugin/api/log.go
+++ b/plugin/api/log.go
@@ -5,6 +5,8 @@
 package api
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,11 +17,16 @@ import (
 	"strings"
 
 	log "github.com/cihub/seelog"
-	"infini.sh/agent/lib/reader/linenumber"
 	agent_util "infini.sh/agent/lib/util"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
+)
+
+const (
+	logReadBufferSize = 64 * 1024
+	maxReadLines      = 200
+	maxCountRowsBytes = 8 * 1024 * 1024
 )
 
 func (handler *AgentAPI) getElasticLogFiles(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
@@ -72,18 +79,23 @@ func (handler *AgentAPI) getSearchLogFiles(w http.ResponseWriter, req *http.Requ
 				continue
 			}
 			filePath := path.Join(resolvedLogsPath, info.Name())
-			totalRows, err := agent_util.CountFileRows(filePath)
-			if err != nil {
-				appendError("failed to count rows for log file [%s]: %v", filePath, err)
-				continue
+			fileItem := util.MapStr{
+				"name":             fInfo.Name(),
+				"logs_path":        resolvedLogsPath,
+				"size_in_bytes":    fInfo.Size(),
+				"modify_time":      fInfo.ModTime(),
+				"total_rows_known": false,
 			}
-			files = append(files, util.MapStr{
-				"name":          fInfo.Name(),
-				"logs_path":     resolvedLogsPath,
-				"size_in_bytes": fInfo.Size(),
-				"modify_time":   fInfo.ModTime(),
-				"total_rows":    totalRows,
-			})
+			if shouldCountLogRows(fInfo.Size()) {
+				totalRows, err := agent_util.CountFileRows(filePath)
+				if err != nil {
+					appendError("failed to count rows for log file [%s]: %v", filePath, err)
+					continue
+				}
+				fileItem["total_rows"] = totalRows
+				fileItem["total_rows_known"] = true
+			}
+			files = append(files, fileItem)
 		}
 	}
 
@@ -159,13 +171,41 @@ func (handler *AgentAPI) readSearchLogFile(w http.ResponseWriter, req *http.Requ
 		}
 		logFilePath = tmpFilePath
 	}
-	r, err := linenumber.NewLinePlainTextReader(logFilePath, reqBody.StartLineNumber, io.SeekStart)
+	var msgs []util.MapStr
+	var isEOF bool
+	if reqBody.TailLines > 0 {
+		msgs, err = readSearchLogTailLines(logFilePath, reqBody.TailLines)
+		isEOF = true
+	} else {
+		msgs, isEOF, err = readSearchLogLines(logFilePath, reqBody.StartLineNumber, reqBody.Offset, reqBody.Lines)
+	}
 	if err != nil {
-		log.Errorf("failed to open search log file [%s], start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
-		handler.WriteJSON(w, err.Error(), http.StatusInternalServerError)
+		log.Errorf("failed to read search log file [%s] at start_line_number=[%d], offset=[%d], tail_lines=[%d]: %v", logFilePath, reqBody.StartLineNumber, reqBody.Offset, reqBody.TailLines, err)
+		handler.WriteError(w, fmt.Sprintf("read logs error: %v", err), http.StatusInternalServerError)
 		return
 	}
+	handler.WriteJSON(w, util.MapStr{
+		"result":  msgs,
+		"success": true,
+		"EOF":     isEOF,
+	}, http.StatusOK)
+}
 
+func readSearchLogLines(filePath string, startLineNumber int64, offset int64, lines int) ([]util.MapStr, bool, error) {
+	if lines <= 0 {
+		lines = 50
+	}
+	if lines > maxReadLines {
+		lines = maxReadLines
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, false, err
+	}
 	defer func() {
 		if !global.Env().IsDebug {
 			if r := recover(); r != nil {
@@ -181,43 +221,194 @@ func (handler *AgentAPI) readSearchLogFile(w http.ResponseWriter, req *http.Requ
 				log.Error("error on exit disk_queue,", v)
 			}
 		}
-		if r != nil {
-			r.Close()
-		}
+		file.Close()
 	}()
 
-	var msgs []util.MapStr
+	currentOffset := int64(0)
+	currentLineNumber := int64(1)
+	lineNumbersKnown := true
+
+	if offset == 0 && startLineNumber < 1 {
+		startLineNumber = 1
+	}
+
+	if offset > 0 {
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
+			return nil, false, err
+		}
+		currentOffset = offset
+		if startLineNumber > 0 {
+			currentLineNumber = startLineNumber
+		} else {
+			currentLineNumber = 0
+			lineNumbersKnown = false
+		}
+	} else {
+		currentLineNumber = startLineNumber
+	}
+
+	reader := bufio.NewReaderSize(file, logReadBufferSize)
+	result := make([]util.MapStr, 0, lines)
 	isEOF := false
-	for i := 0; i < reqBody.Lines; i++ {
-		msg, err := r.Next()
-		if err != nil {
+
+	for len(result) < lines {
+		rawLine, err := reader.ReadBytes('\n')
+		if err != nil && err != io.EOF {
+			return result, false, err
+		}
+		if len(rawLine) == 0 {
 			if err == io.EOF {
 				isEOF = true
-				break
 			}
-			log.Errorf("failed to read search log file [%s] at start_line_number=[%d]: %v", logFilePath, reqBody.StartLineNumber, err)
-			handler.WriteError(w, fmt.Sprintf("read logs error: %v", err), http.StatusInternalServerError)
-			return
+			break
 		}
-		msgs = append(msgs, util.MapStr{
-			"content":     string(msg.Content),
-			"bytes":       msg.Bytes,
-			"offset":      msg.Offset,
-			"line_number": coverLineNumbers(msg.LineNumbers),
-		})
+
+		currentOffset += int64(len(rawLine))
+		lineContent := trimLogLineEnding(rawLine)
+
+		if offset > 0 {
+			line := util.MapStr{
+				"content": string(lineContent),
+				"bytes":   len(rawLine),
+				"offset":  currentOffset,
+			}
+			if lineNumbersKnown {
+				line["line_number"] = currentLineNumber
+				currentLineNumber++
+			}
+			result = append(result, line)
+		} else {
+			if currentLineNumber >= startLineNumber {
+				line := util.MapStr{
+					"content": string(lineContent),
+					"bytes":   len(rawLine),
+					"offset":  currentOffset,
+				}
+				if lineNumbersKnown {
+					line["line_number"] = currentLineNumber
+				}
+				result = append(result, line)
+			}
+			currentLineNumber++
+		}
+
+		if err == io.EOF {
+			isEOF = true
+			break
+		}
 	}
-	handler.WriteJSON(w, util.MapStr{
-		"result":  msgs,
-		"success": true,
-		"EOF":     isEOF,
-	}, http.StatusOK)
+
+	return result, isEOF, nil
 }
 
-func coverLineNumbers(numbers []int64) interface{} {
-	if len(numbers) == 1 {
-		return numbers[0]
+func readSearchLogTailLines(filePath string, lines int) ([]util.MapStr, error) {
+	if lines <= 0 {
+		lines = 50
 	}
-	return numbers
+	if lines > maxReadLines {
+		lines = maxReadLines
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size() == 0 {
+		return []util.MapStr{}, nil
+	}
+
+	windowStart, windowBytes, err := locateTailWindow(file, stat.Size(), lines)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bufio.NewReaderSize(bytes.NewReader(windowBytes), logReadBufferSize)
+	currentOffset := windowStart
+	result := make([]util.MapStr, 0, lines)
+
+	for len(result) < lines {
+		rawLine, err := reader.ReadBytes('\n')
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if len(rawLine) == 0 {
+			break
+		}
+
+		currentOffset += int64(len(rawLine))
+		result = append(result, util.MapStr{
+			"content": string(trimLogLineEnding(rawLine)),
+			"bytes":   len(rawLine),
+			"offset":  currentOffset,
+		})
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func locateTailWindow(file *os.File, fileSize int64, lines int) (int64, []byte, error) {
+	position := fileSize
+	window := make([]byte, 0)
+	newlineCount := 0
+
+	for position > 0 && newlineCount <= lines {
+		chunkSize := int64(logReadBufferSize)
+		if position < chunkSize {
+			chunkSize = position
+		}
+		position -= chunkSize
+
+		chunk := make([]byte, chunkSize)
+		if _, err := file.ReadAt(chunk, position); err != nil && err != io.EOF {
+			return 0, nil, err
+		}
+		window = append(chunk, window...)
+		newlineCount += bytes.Count(chunk, []byte{'\n'})
+	}
+
+	startIndex := findTailStartIndex(window, lines)
+	return position + int64(startIndex), window[startIndex:], nil
+}
+
+func findTailStartIndex(window []byte, lines int) int {
+	if len(window) == 0 || lines <= 0 {
+		return 0
+	}
+
+	idx := len(window) - 1
+	if window[idx] == '\n' {
+		idx--
+	}
+
+	newlineCount := 0
+	for ; idx >= 0; idx-- {
+		if window[idx] != '\n' {
+			continue
+		}
+		newlineCount++
+		if newlineCount == lines {
+			return idx + 1
+		}
+	}
+	return 0
+}
+
+func shouldCountLogRows(fileSize int64) bool {
+	return fileSize >= 0 && fileSize <= maxCountRowsBytes
+}
+
+func trimLogLineEnding(rawLine []byte) []byte {
+	return bytes.TrimRight(rawLine, "\r\n")
 }
 
 func resolveLogsDirectory(logsPath string) (string, error) {

--- a/plugin/api/log_test.go
+++ b/plugin/api/log_test.go
@@ -1,6 +1,10 @@
 package api
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestNormalizeJSONLogsPathsSupportsStringAndArray(t *testing.T) {
 	paths := normalizeJSONLogsPaths("/var/log/elasticsearch")
@@ -22,5 +26,97 @@ func TestSafeJoinLogsFileRejectsTraversal(t *testing.T) {
 
 	if _, err := safeJoinLogsFile("/var/log/elasticsearch", "../server.log"); err == nil {
 		t.Fatal("expected traversal to be rejected")
+	}
+}
+
+func TestReadSearchLogLinesUsesRealOffset(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "server.log")
+	content := "first\r\nsecond\r\nthird"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp log file: %v", err)
+	}
+
+	lines, isEOF, err := readSearchLogLines(filePath, 1, 0, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isEOF {
+		t.Fatal("expected more content after first page")
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %#v", lines)
+	}
+	if lines[0]["offset"] != int64(7) || lines[1]["offset"] != int64(15) {
+		t.Fatalf("unexpected offsets: %#v", lines)
+	}
+
+	lines, isEOF, err = readSearchLogLines(filePath, 3, lines[1]["offset"].(int64), 2)
+	if err != nil {
+		t.Fatalf("unexpected error on second page: %v", err)
+	}
+	if !isEOF {
+		t.Fatal("expected EOF on second page")
+	}
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %#v", lines)
+	}
+	if lines[0]["line_number"] != int64(3) || lines[0]["content"] != "third" {
+		t.Fatalf("unexpected second page data: %#v", lines[0])
+	}
+}
+
+func TestReadSearchLogLinesKeepsLineNumbersUnknownAfterTailMode(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "server.log")
+	content := "first\nsecond\nthird\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp log file: %v", err)
+	}
+
+	lines, _, err := readSearchLogLines(filePath, 0, 6, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %#v", lines)
+	}
+	if _, ok := lines[0]["line_number"]; ok {
+		t.Fatalf("line number should stay unknown after offset-only reads: %#v", lines[0])
+	}
+}
+
+func TestReadSearchLogTailLinesReturnsLatestOffsets(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "server.log")
+	content := "first\nsecond\nthird\nfourth\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp log file: %v", err)
+	}
+
+	lines, err := readSearchLogTailLines(filePath, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %#v", lines)
+	}
+	if lines[0]["content"] != "third" || lines[1]["content"] != "fourth" {
+		t.Fatalf("unexpected tail lines: %#v", lines)
+	}
+	if lines[0]["offset"] != int64(19) || lines[1]["offset"] != int64(26) {
+		t.Fatalf("unexpected tail offsets: %#v", lines)
+	}
+	if _, ok := lines[0]["line_number"]; ok {
+		t.Fatalf("tail reads should not claim absolute line numbers: %#v", lines[0])
+	}
+}
+
+func TestShouldCountLogRows(t *testing.T) {
+	if !shouldCountLogRows(maxCountRowsBytes) {
+		t.Fatal("expected row counts for small files")
+	}
+	if shouldCountLogRows(maxCountRowsBytes + 1) {
+		t.Fatal("expected row counts to be skipped for large files")
 	}
 }

--- a/plugin/api/model.go
+++ b/plugin/api/model.go
@@ -14,4 +14,5 @@ type ReadSearchLogFileReq struct {
 	Offset          int64  `json:"offset"`
 	Lines           int    `json:"lines"`
 	StartLineNumber int64  `json:"start_line_number"`
+	TailLines       int    `json:"tail_lines"`
 }

--- a/plugin/api/protected_api_routes.go
+++ b/plugin/api/protected_api_routes.go
@@ -17,6 +17,8 @@ type protectedAPIRouter struct {
 	router *httprouter.Router
 }
 
+var noopProtectedAPIRouteHandle = func(http.ResponseWriter, *http.Request, httprouter.Params) {}
+
 var protectedAPIRoutes = []protectedAPIRoute{
 	{http.MethodGet, "/stats"},
 	{http.MethodGet, "/queue/stats"},
@@ -54,7 +56,7 @@ func newReverseAPIRouter(agentAPI AgentAPI) *protectedAPIRouter {
 	router.Handle(http.MethodPost, "/elasticsearch/node/_info", agentAPI.getESNodeInfo)
 	router.Handle(http.MethodPost, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles)
 	router.Handle(http.MethodPost, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile)
-	registerProtectedAPIRoutes(router.router, agentAPI.proxyProtectedAPI)
+	registerProtectedAPIRoutes(router.router, noopProtectedAPIRouteHandle)
 	return router
 }
 

--- a/plugin/api/protected_api_routes.go
+++ b/plugin/api/protected_api_routes.go
@@ -31,6 +31,8 @@ var protectedAPIRoutes = []protectedAPIRoute{
 	{http.MethodGet, "/config/"},
 	{http.MethodPut, "/config/"},
 	{http.MethodGet, "/config/runtime"},
+	{http.MethodGet, "/setting/logger"},
+	{http.MethodPost, "/setting/logger"},
 }
 
 func registerProtectedAPIRoutes(router *httprouter.Router, handle httprouter.Handle) {

--- a/plugin/api/protected_api_routes.go
+++ b/plugin/api/protected_api_routes.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 
 	httprouter "infini.sh/framework/core/api/router"
 )
@@ -9,6 +11,10 @@ import (
 type protectedAPIRoute struct {
 	method string
 	path   string
+}
+
+type protectedAPIRouter struct {
+	router *httprouter.Router
 }
 
 var protectedAPIRoutes = []protectedAPIRoute{
@@ -33,6 +39,54 @@ var protectedAPIRoutes = []protectedAPIRoute{
 	{http.MethodGet, "/config/runtime"},
 	{http.MethodGet, "/setting/logger"},
 	{http.MethodPost, "/setting/logger"},
+}
+
+func newProtectedAPIRouter(handle httprouter.Handle) *protectedAPIRouter {
+	router := &protectedAPIRouter{router: httprouter.New(nil)}
+	registerProtectedAPIRoutes(router.router, handle)
+	return router
+}
+
+func newReverseAPIRouter(agentAPI AgentAPI) *protectedAPIRouter {
+	router := &protectedAPIRouter{router: httprouter.New(nil)}
+	router.Handle(http.MethodGet, "/agent/_info", agentAPI.getAgentInfo)
+	router.Handle(http.MethodGet, "/elasticsearch/node/_discovery", agentAPI.getESNodes)
+	router.Handle(http.MethodPost, "/elasticsearch/node/_info", agentAPI.getESNodeInfo)
+	router.Handle(http.MethodPost, "/elasticsearch/logs/_list", agentAPI.getElasticLogFiles)
+	router.Handle(http.MethodPost, "/elasticsearch/logs/_read", agentAPI.readElasticLogFile)
+	registerProtectedAPIRoutes(router.router, agentAPI.proxyProtectedAPI)
+	return router
+}
+
+func (r *protectedAPIRouter) Handle(method, path string, handle httprouter.Handle) {
+	if r == nil || r.router == nil {
+		return
+	}
+	r.router.Handle(method, path, handle)
+}
+
+func (r *protectedAPIRouter) Match(method, rawPath string) bool {
+	if r == nil || r.router == nil {
+		return false
+	}
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(rawPath))
+	if err != nil || parsed.Path == "" {
+		return false
+	}
+	handle, _, _ := r.router.Lookup(strings.ToUpper(method), parsed.Path)
+	return handle != nil
+}
+
+func (r *protectedAPIRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) bool {
+	if r == nil || r.router == nil || req == nil || req.URL == nil {
+		return false
+	}
+	handle, _, _ := r.router.Lookup(strings.ToUpper(req.Method), req.URL.Path)
+	if handle == nil {
+		return false
+	}
+	r.router.ServeHTTP(w, req)
+	return true
 }
 
 func registerProtectedAPIRoutes(router *httprouter.Router, handle httprouter.Handle) {

--- a/plugin/api/protected_api_routes.go
+++ b/plugin/api/protected_api_routes.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"net/http"
+
+	httprouter "infini.sh/framework/core/api/router"
+)
+
+type protectedAPIRoute struct {
+	method string
+	path   string
+}
+
+var protectedAPIRoutes = []protectedAPIRoute{
+	{http.MethodGet, "/stats"},
+	{http.MethodGet, "/queue/stats"},
+	{http.MethodGet, "/queue/:id/stats"},
+	{http.MethodGet, "/queue/:id/_scroll"},
+	{http.MethodDelete, "/queue/:id"},
+	{http.MethodDelete, "/queue/_search"},
+	{http.MethodPut, "/queue/:id/consumer/:consumer_id/offset"},
+	{http.MethodGet, "/queue/:id/consumer/:consumer_id/offset"},
+	{http.MethodDelete, "/queue/:id/consumer/:consumer_id"},
+	{http.MethodDelete, "/queue/consumer/_search"},
+	{http.MethodGet, "/pipeline/tasks/"},
+	{http.MethodPost, "/pipeline/tasks/_search"},
+	{http.MethodPost, "/pipeline/task/:id/_start"},
+	{http.MethodPost, "/pipeline/task/:id/_stop"},
+	{http.MethodGet, "/pipeline/task/:id"},
+	{http.MethodDelete, "/pipeline/task/:id"},
+	{http.MethodGet, "/config/"},
+	{http.MethodPut, "/config/"},
+	{http.MethodGet, "/config/runtime"},
+}
+
+func registerProtectedAPIRoutes(router *httprouter.Router, handle httprouter.Handle) {
+	for _, route := range protectedAPIRoutes {
+		router.Handle(route.method, route.path, handle)
+	}
+}

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -239,6 +239,11 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 		handler.getElasticLogFiles(recorder, req, nil)
 	case "/elasticsearch/logs/_read":
 		handler.readElasticLogFile(recorder, req, nil)
+	case "/stats":
+		if err := api.ServeRegisteredUIRequest(recorder, req); err != nil {
+			recorder.WriteHeader(http.StatusServiceUnavailable)
+			recorder.Write(buildAgentReverseErrorBody(http.StatusServiceUnavailable, err.Error()))
+		}
 	default:
 		recorder.WriteHeader(http.StatusNotFound)
 		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -22,43 +22,17 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/websocket"
 	"infini.sh/framework/core/api"
+	framework_reverse "infini.sh/framework/core/api/websocket/reverse"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 	configcommon "infini.sh/framework/modules/configs/common"
 )
 
 const (
-	reverseChannelHeaderInstanceID = "X-INFINI-INSTANCE-ID"
-	reverseHelloCommand            = "reverse_hello"
-	reverseRequestCommand          = "reverse_request"
-	reverseResponseCommand         = "reverse_response"
 	reverseChannelTag              = "agent_reverse_channel"
 	reverseReconnectDelay          = 5 * time.Second
 	reverseMaxIncomingMessageBytes = 8 * 1024 * 1024
-	reverseResponseChunkBytes      = 32 * 1024
 )
-
-type agentReverseHelloMessage struct {
-	SessionID  string `json:"session_id"`
-	InstanceID string `json:"instance_id"`
-}
-
-type agentReverseRequestMessage struct {
-	RequestID   string `json:"request_id"`
-	InstanceID  string `json:"instance_id"`
-	Method      string `json:"method"`
-	Path        string `json:"path"`
-	Body        string `json:"body,omitempty"`
-	AccessToken string `json:"access_token,omitempty"`
-}
-
-type agentReverseResponseMessage struct {
-	RequestID  string `json:"request_id"`
-	InstanceID string `json:"instance_id"`
-	Chunk      string `json:"chunk,omitempty"`
-	Status     int    `json:"status,omitempty"`
-	Done       bool   `json:"done,omitempty"`
-}
 
 var agentReverseChannelRunning atomic.Bool
 var agentReverseChannelWriteLock sync.Mutex
@@ -153,7 +127,7 @@ func dialAgentReverseChannel(server string) (*websocket.Conn, error) {
 	}
 
 	headers := http.Header{}
-	headers.Set(reverseChannelHeaderInstanceID, global.Env().SystemConfig.NodeConfig.ID)
+	headers.Set(framework_reverse.HeaderPeerID, global.Env().SystemConfig.NodeConfig.ID)
 	managerToken, err := configcommon.LoadTokenFromKeystore(configcommon.ManagerTokenKeystoreKey)
 	if err != nil {
 		return nil, err
@@ -205,15 +179,14 @@ func handleAgentReverseChannelMessage(conn *websocket.Conn, payload []byte) {
 		if strings.HasPrefix(parts[1], "websocket-session-id:") {
 			sessionID := strings.TrimSpace(strings.TrimPrefix(parts[1], "websocket-session-id:"))
 			if sessionID != "" {
-				helloPayload := string(util.MustToJSONBytes(agentReverseHelloMessage{
-					SessionID:  sessionID,
-					InstanceID: global.Env().SystemConfig.NodeConfig.ID,
+				_ = writeAgentReverseText(conn, framework_reverse.FormatHelloCommand(framework_reverse.HelloMessage{
+					SessionID: sessionID,
+					PeerID:    global.Env().SystemConfig.NodeConfig.ID,
 				}))
-				_ = writeAgentReverseText(conn, reverseHelloCommand+" "+helloPayload)
 			}
 		}
 	case "PRIVATE":
-		prefix := reverseRequestCommand + " "
+		prefix := framework_reverse.RequestCommand + " "
 		if strings.HasPrefix(parts[1], prefix) {
 			go handleAgentReverseRequest(conn, strings.TrimPrefix(parts[1], prefix))
 		}
@@ -221,34 +194,30 @@ func handleAgentReverseChannelMessage(conn *websocket.Conn, payload []byte) {
 }
 
 func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
-	reqMsg := agentReverseRequestMessage{}
-	if err := util.FromJSONBytes([]byte(payload), &reqMsg); err != nil {
+	reqMsg, err := framework_reverse.ParseRequestPayload(payload)
+	if err != nil {
 		body := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
-		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
+		_ = writeAgentReverseResponse(conn, "", global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
 		return
 	}
-	if !validateAgentAccessToken(reqMsg.AccessToken) {
+	if !validateAgentAccessToken(reqMsg.BearerToken()) {
 		body := buildAgentReverseErrorBody(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
-		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusUnauthorized, body)
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.PeerID, http.StatusUnauthorized, body)
 		return
 	}
 
-	body := []byte(nil)
-	if reqMsg.Body != "" {
-		decoded, err := base64.StdEncoding.DecodeString(reqMsg.Body)
-		if err != nil {
-			errBody := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
-			_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusBadRequest, errBody)
-			return
-		}
-		body = decoded
+	body, err := reqMsg.BodyBytes()
+	if err != nil {
+		errBody := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.PeerID, http.StatusBadRequest, errBody)
+		return
 	}
 
-	status, responseBody := executeAgentReverseRequest(reqMsg.Method, reqMsg.Path, body)
-	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, status, responseBody)
+	status, responseBody := executeAgentReverseRequest(reqMsg.Method, reqMsg.Path, body, reqMsg)
+	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.PeerID, status, responseBody)
 }
 
-func executeAgentReverseRequest(method, requestPath string, body []byte) (status int, responseBody []byte) {
+func executeAgentReverseRequest(method, requestPath string, body []byte, reqMsg framework_reverse.RequestMessage) (status int, responseBody []byte) {
 	defer func() {
 		if r := recover(); r != nil {
 			status = http.StatusInternalServerError
@@ -261,7 +230,10 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 		bodyReader = bytes.NewReader(body)
 	}
 	req := httptest.NewRequest(method, "http://agent"+requestPath, bodyReader)
-	req.Header.Set("Content-Type", util.ContentTypeJson)
+	reqMsg.ApplyHeaders(req)
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", util.ContentTypeJson)
+	}
 	recorder := httptest.NewRecorder()
 	if _, err := url.ParseRequestURI(requestPath); err != nil {
 		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
@@ -286,28 +258,9 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 }
 
 func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte) error {
-	for start := 0; start < len(body); start += reverseResponseChunkBytes {
-		end := start + reverseResponseChunkBytes
-		if end > len(body) {
-			end = len(body)
-		}
-		msg := agentReverseResponseMessage{
-			RequestID:  requestID,
-			InstanceID: instanceID,
-			Chunk:      base64.StdEncoding.EncodeToString(body[start:end]),
-		}
-		if err := writeAgentReverseText(conn, reverseResponseCommand+" "+string(util.MustToJSONBytes(msg))); err != nil {
-			return err
-		}
-	}
-
-	doneMsg := agentReverseResponseMessage{
-		RequestID:  requestID,
-		InstanceID: instanceID,
-		Status:     status,
-		Done:       true,
-	}
-	return writeAgentReverseText(conn, reverseResponseCommand+" "+string(util.MustToJSONBytes(doneMsg)))
+	return framework_reverse.WriteChunkedResponse(func(payload string) error {
+		return writeAgentReverseText(conn, payload)
+	}, requestID, instanceID, status, body, framework_reverse.DefaultResponseChunkBytes)
 }
 
 func writeAgentReverseText(conn *websocket.Conn, payload string) error {

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -44,11 +45,12 @@ type agentReverseHelloMessage struct {
 }
 
 type agentReverseRequestMessage struct {
-	RequestID  string `json:"request_id"`
-	InstanceID string `json:"instance_id"`
-	Method     string `json:"method"`
-	Path       string `json:"path"`
-	Body       string `json:"body,omitempty"`
+	RequestID   string `json:"request_id"`
+	InstanceID  string `json:"instance_id"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Body        string `json:"body,omitempty"`
+	AccessToken string `json:"access_token,omitempty"`
 }
 
 type agentReverseResponseMessage struct {
@@ -169,8 +171,14 @@ func dialAgentReverseChannel(server string) (*websocket.Conn, error) {
 
 	headers := http.Header{}
 	headers.Set(agentReverseChannelHeaderInstanceID, global.Env().SystemConfig.NodeConfig.ID)
+	managerToken, err := configcommon.LoadTokenFromKeystore(configcommon.ManagerTokenKeystoreKey)
+	if err != nil {
+		return nil, err
+	}
 	managerAuth := global.Env().SystemConfig.Configs.ManagerConfig.BasicAuth
-	if managerAuth.Username != "" {
+	if managerToken != "" {
+		headers.Set("Authorization", "Bearer "+managerToken)
+	} else if managerAuth.Username != "" {
 		token := base64.StdEncoding.EncodeToString([]byte(managerAuth.Username + ":" + managerAuth.Password.Get()))
 		headers.Set("Authorization", "Basic "+token)
 	}
@@ -235,6 +243,11 @@ func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
 		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
 		return
 	}
+	if !validateAgentAccessToken(reqMsg.AccessToken) {
+		body := buildAgentReverseErrorBody(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusUnauthorized, body)
+		return
+	}
 
 	body := []byte(nil)
 	if reqMsg.Body != "" {
@@ -273,6 +286,8 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 	}
 
 	switch parsedPath.Path {
+	case "/agent/_info":
+		handler.getAgentInfo(recorder, req, nil)
 	case "/elasticsearch/node/_discovery":
 		handler.getESNodes(recorder, req, nil)
 	case "/elasticsearch/node/_info":
@@ -341,4 +356,12 @@ func buildAgentReverseErrorBody(status int, reason string) []byte {
 		},
 		"status": status,
 	})
+}
+
+func validateAgentAccessToken(tokenValue string) bool {
+	expected, err := configcommon.LoadTokenFromKeystore(configcommon.AgentAccessTokenKeystoreKey)
+	if err != nil || expected == "" || tokenValue == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(tokenValue)) == 1
 }

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -332,46 +332,23 @@ func executeAgentReverseRequest(method, requestPath string, body []byte, reqMsg 
 }
 
 func executeAgentRegisteredAPIReverse(method, requestPath string, body []byte, reqMsg framework_reverse.RequestMessage) (status int, responseBody []byte) {
-	target, err := agentReverseAPIProxyTargetResolver()
-	if err != nil {
-		log.Warnf("agent reverse channel cannot proxy request [%s %s]: %v", method, requestPath, err)
-		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
-	}
-
-	proxyURL, err := buildAgentReverseProxyURL(target.endpoint, target.basePath, requestPath)
-	if err != nil {
-		log.Warnf("agent reverse channel cannot build proxy URL for [%s %s]: %v", method, requestPath, err)
-		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
-	}
-
 	var bodyReader io.Reader
 	if len(body) > 0 {
 		bodyReader = bytes.NewReader(body)
 	}
-	req, err := http.NewRequest(method, proxyURL, bodyReader)
+	req, err := http.NewRequest(method, "http://agent"+requestPath, bodyReader)
 	if err != nil {
-		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
 	}
 	reqMsg.ApplyHeaders(req)
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", util.ContentTypeJson)
 	}
-	if target.basicAuthUser != "" {
-		req.SetBasicAuth(target.basicAuthUser, target.basicAuthPass)
-	}
-
-	client, err := agentReverseHTTPClientFactory(target)
-	if err != nil {
-		log.Warnf("agent reverse channel cannot build HTTP client for [%s %s]: %v", method, requestPath, err)
-		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
-	}
-	result, err := client.Do(req)
-	if err != nil {
-		log.Warnf("agent reverse channel proxy request failed [%s %s -> %s]: %v", method, requestPath, proxyURL, err)
-		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
-	}
+	applyAgentReverseLocalAPIAuth(req)
+	recorder := httptest.NewRecorder()
+	api.ServeRegisteredAPIRequest(recorder, req)
+	result := recorder.Result()
 	defer result.Body.Close()
-
 	responseBody, _ = io.ReadAll(result.Body)
 	status = result.StatusCode
 	if status == 0 {
@@ -381,6 +358,21 @@ func executeAgentRegisteredAPIReverse(method, requestPath string, body []byte, r
 		responseBody = buildAgentReverseErrorBody(status, http.StatusText(status))
 	}
 	return status, responseBody
+}
+
+func applyAgentReverseLocalAPIAuth(req *http.Request) {
+	if req == nil {
+		return
+	}
+	apiCfg := global.Env().SystemConfig.APIConfig
+	if !apiCfg.Security.Enabled {
+		return
+	}
+	username := strings.TrimSpace(apiCfg.Security.Username)
+	if username == "" {
+		return
+	}
+	req.SetBasicAuth(username, apiCfg.Security.Password)
 }
 
 func resolveAgentReverseAPIProxyTarget() (agentReverseProxyTarget, error) {

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -33,9 +33,6 @@ const (
 	reverseHelloCommand            = "reverse_hello"
 	reverseRequestCommand          = "reverse_request"
 	reverseResponseCommand         = "reverse_response"
-	legacyReverseHelloCommand      = "agent_reverse_hello"
-	legacyReverseRequestCommand    = "agent_reverse_request"
-	legacyReverseResponseCommand   = "agent_reverse_response"
 	reverseChannelTag              = "agent_reverse_channel"
 	reverseReconnectDelay          = 5 * time.Second
 	reverseMaxIncomingMessageBytes = 8 * 1024 * 1024
@@ -230,43 +227,26 @@ func handleAgentReverseChannelMessage(conn *websocket.Conn, payload []byte) {
 					InstanceID: global.Env().SystemConfig.NodeConfig.ID,
 				}))
 				_ = writeAgentReverseText(conn, reverseHelloCommand+" "+helloPayload)
-				_ = writeAgentReverseText(conn, legacyReverseHelloCommand+" "+helloPayload)
 			}
 		}
 	case "PRIVATE":
-		if command, body, ok := matchReverseRequestCommand(parts[1]); ok {
-			go handleAgentReverseRequest(conn, strings.TrimPrefix(parts[1], body), command)
+		prefix := reverseRequestCommand + " "
+		if strings.HasPrefix(parts[1], prefix) {
+			go handleAgentReverseRequest(conn, strings.TrimPrefix(parts[1], prefix))
 		}
 	}
 }
 
-func matchReverseRequestCommand(payload string) (command, prefix string, ok bool) {
-	for _, candidate := range []string{reverseRequestCommand, legacyReverseRequestCommand} {
-		prefix = candidate + " "
-		if strings.HasPrefix(payload, prefix) {
-			return candidate, prefix, true
-		}
-	}
-	return "", "", false
-}
-
-func responseCommandForRequest(command string) string {
-	if command == legacyReverseRequestCommand {
-		return legacyReverseResponseCommand
-	}
-	return reverseResponseCommand
-}
-
-func handleAgentReverseRequest(conn *websocket.Conn, payload string, requestCommand string) {
+func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
 	reqMsg := agentReverseRequestMessage{}
 	if err := util.FromJSONBytes([]byte(payload), &reqMsg); err != nil {
 		body := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
-		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body, responseCommandForRequest(requestCommand))
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
 		return
 	}
 	if !validateAgentAccessToken(reqMsg.AccessToken) {
 		body := buildAgentReverseErrorBody(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
-		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusUnauthorized, body, responseCommandForRequest(requestCommand))
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusUnauthorized, body)
 		return
 	}
 
@@ -275,14 +255,14 @@ func handleAgentReverseRequest(conn *websocket.Conn, payload string, requestComm
 		decoded, err := base64.StdEncoding.DecodeString(reqMsg.Body)
 		if err != nil {
 			errBody := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
-			_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusBadRequest, errBody, responseCommandForRequest(requestCommand))
+			_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusBadRequest, errBody)
 			return
 		}
 		body = decoded
 	}
 
 	status, responseBody := executeAgentReverseRequest(reqMsg.Method, reqMsg.Path, body)
-	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, status, responseBody, responseCommandForRequest(requestCommand))
+	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, status, responseBody)
 }
 
 func executeAgentReverseRequest(method, requestPath string, body []byte) (status int, responseBody []byte) {
@@ -339,7 +319,7 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 	return status, responseBody
 }
 
-func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte, command string) error {
+func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte) error {
 	for start := 0; start < len(body); start += reverseResponseChunkBytes {
 		end := start + reverseResponseChunkBytes
 		if end > len(body) {
@@ -350,7 +330,7 @@ func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID strin
 			InstanceID: instanceID,
 			Chunk:      base64.StdEncoding.EncodeToString(body[start:end]),
 		}
-		if err := writeAgentReverseText(conn, command+" "+string(util.MustToJSONBytes(msg))); err != nil {
+		if err := writeAgentReverseText(conn, reverseResponseCommand+" "+string(util.MustToJSONBytes(msg))); err != nil {
 			return err
 		}
 	}
@@ -361,7 +341,7 @@ func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID strin
 		Status:     status,
 		Done:       true,
 	}
-	return writeAgentReverseText(conn, command+" "+string(util.MustToJSONBytes(doneMsg)))
+	return writeAgentReverseText(conn, reverseResponseCommand+" "+string(util.MustToJSONBytes(doneMsg)))
 }
 
 func writeAgentReverseText(conn *websocket.Conn, payload string) error {

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/websocket"
 	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 )
@@ -33,7 +34,7 @@ const (
 	agentReverseChannelTag              = "agent_reverse_channel"
 	agentReverseReconnectDelay          = 5 * time.Second
 	agentReverseMaxIncomingMessageBytes = 1024 * 1024
-	agentReverseResponseChunkBytes      = 160
+	agentReverseResponseChunkBytes      = 32 * 1024
 )
 
 type agentReverseHelloMessage struct {
@@ -59,6 +60,49 @@ type agentReverseResponseMessage struct {
 
 var agentReverseChannelRunning atomic.Bool
 var agentReverseChannelWriteLock sync.Mutex
+var agentReverseAPIPathMatcher = newAgentReverseAPIPathMatcher()
+
+func newAgentReverseAPIPathMatcher() *httprouter.Router {
+	router := httprouter.New(nil)
+	handle := func(http.ResponseWriter, *http.Request, httprouter.Params) {}
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/stats"},
+		{http.MethodGet, "/queue/stats"},
+		{http.MethodGet, "/queue/:id/stats"},
+		{http.MethodGet, "/queue/:id/_scroll"},
+		{http.MethodDelete, "/queue/:id"},
+		{http.MethodDelete, "/queue/_search"},
+		{http.MethodPut, "/queue/:id/consumer/:consumer_id/offset"},
+		{http.MethodGet, "/queue/:id/consumer/:consumer_id/offset"},
+		{http.MethodDelete, "/queue/:id/consumer/:consumer_id"},
+		{http.MethodDelete, "/queue/consumer/_search"},
+		{http.MethodGet, "/pipeline/tasks/"},
+		{http.MethodPost, "/pipeline/tasks/_search"},
+		{http.MethodPost, "/pipeline/task/:id/_start"},
+		{http.MethodPost, "/pipeline/task/:id/_stop"},
+		{http.MethodGet, "/pipeline/task/:id"},
+		{http.MethodDelete, "/pipeline/task/:id"},
+		{http.MethodGet, "/config/"},
+		{http.MethodPut, "/config/"},
+		{http.MethodGet, "/config/runtime"},
+	}
+	for _, route := range routes {
+		router.Handle(route.method, route.path, handle)
+	}
+	return router
+}
+
+func shouldServeRegisteredAPIReverse(method, rawPath string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(rawPath))
+	if err != nil || parsed.Path == "" {
+		return false
+	}
+	handle, _, _ := agentReverseAPIPathMatcher.Lookup(strings.ToUpper(method), parsed.Path)
+	return handle != nil
+}
 
 func registerAgentReverseChannel() {
 	global.RegisterBackgroundCallback(&global.BackgroundTask{
@@ -229,8 +273,12 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 	req.Header.Set("Content-Type", util.ContentTypeJson)
 	recorder := httptest.NewRecorder()
 	handler := AgentAPI{}
+	parsedPath, err := url.ParseRequestURI(requestPath)
+	if err != nil {
+		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+	}
 
-	switch requestPath {
+	switch parsedPath.Path {
 	case "/elasticsearch/node/_discovery":
 		handler.getESNodes(recorder, req, nil)
 	case "/elasticsearch/node/_info":
@@ -239,12 +287,11 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 		handler.getElasticLogFiles(recorder, req, nil)
 	case "/elasticsearch/logs/_read":
 		handler.readElasticLogFile(recorder, req, nil)
-	case "/stats":
-		if err := api.ServeRegisteredUIRequest(recorder, req); err != nil {
-			recorder.WriteHeader(http.StatusServiceUnavailable)
-			recorder.Write(buildAgentReverseErrorBody(http.StatusServiceUnavailable, err.Error()))
-		}
 	default:
+		if shouldServeRegisteredAPIReverse(method, requestPath) {
+			api.ServeRegisteredAPIRequest(recorder, req)
+			break
+		}
 		recorder.WriteHeader(http.StatusNotFound)
 		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))
 	}

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -22,27 +22,55 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/websocket"
 	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
 	framework_reverse "infini.sh/framework/core/api/websocket/reverse"
+	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 	configcommon "infini.sh/framework/modules/configs/common"
 )
 
 const (
-	reverseChannelTag              = "agent_reverse_channel"
-	reverseReconnectDelay          = 5 * time.Second
-	reverseMaxIncomingMessageBytes = 8 * 1024 * 1024
+	agentReverseChannelTag              = "agent_reverse_channel"
+	agentReverseReconnectDelay          = 5 * time.Second
+	agentReverseMaxIncomingMessageBytes = 8 * 1024 * 1024
 )
+
+type agentReverseProxyTarget struct {
+	endpoint      string
+	basePath      string
+	tlsConfig     config.TLSConfig
+	basicAuthUser string
+	basicAuthPass string
+}
 
 var agentReverseChannelRunning atomic.Bool
 var agentReverseChannelWriteLock sync.Mutex
-var agentReverseAPIs = newReverseAPIRouter(AgentAPI{})
+var agentReverseAPIPathMatcher = newAgentReverseAPIPathMatcher()
+var agentReverseAPIProxyTargetResolver = resolveAgentReverseAPIProxyTarget
+var agentReverseHTTPClientFactory = newAgentReverseHTTPClient
+
+func newAgentReverseAPIPathMatcher() *httprouter.Router {
+	router := httprouter.New(nil)
+	handle := func(http.ResponseWriter, *http.Request, httprouter.Params) {}
+	registerProtectedAPIRoutes(router, handle)
+	return router
+}
+
+func shouldServeRegisteredAPIReverse(method, rawPath string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(rawPath))
+	if err != nil || parsed.Path == "" {
+		return false
+	}
+	handle, _, _ := agentReverseAPIPathMatcher.Lookup(strings.ToUpper(method), parsed.Path)
+	return handle != nil
+}
 
 func registerAgentReverseChannel() {
 	global.RegisterBackgroundCallback(&global.BackgroundTask{
-		Tag:          reverseChannelTag,
-		Interval:     reverseReconnectDelay,
-		InitialDelay: reverseReconnectDelay,
+		Tag:          agentReverseChannelTag,
+		Interval:     agentReverseReconnectDelay,
+		InitialDelay: agentReverseReconnectDelay,
 		Func:         ensureAgentReverseChannel,
 	})
 }
@@ -69,7 +97,7 @@ func runAgentReverseChannel() {
 		if global.ShuttingDown() {
 			return
 		}
-		time.Sleep(reverseReconnectDelay)
+		time.Sleep(agentReverseReconnectDelay)
 	}
 }
 
@@ -82,7 +110,7 @@ func connectAndServeAgentReverseChannel() error {
 			continue
 		}
 		defer conn.Close()
-		conn.SetReadLimit(reverseMaxIncomingMessageBytes)
+		conn.SetReadLimit(agentReverseMaxIncomingMessageBytes)
 
 		for {
 			messageType, payload, err := conn.ReadMessage()
@@ -243,11 +271,27 @@ func executeAgentReverseRequest(method, requestPath string, body []byte, reqMsg 
 		req.Header.Set("Content-Type", util.ContentTypeJson)
 	}
 	recorder := httptest.NewRecorder()
-	if _, err := url.ParseRequestURI(requestPath); err != nil {
+	handler := AgentAPI{}
+	parsedPath, err := url.ParseRequestURI(requestPath)
+	if err != nil {
 		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
 	}
 
-	if !agentReverseAPIs.ServeHTTP(recorder, req) {
+	switch parsedPath.Path {
+	case "/agent/_info":
+		handler.getAgentInfo(recorder, req, nil)
+	case "/elasticsearch/node/_discovery":
+		handler.getESNodes(recorder, req, nil)
+	case "/elasticsearch/node/_info":
+		handler.getESNodeInfo(recorder, req, nil)
+	case "/elasticsearch/logs/_list":
+		handler.getElasticLogFiles(recorder, req, nil)
+	case "/elasticsearch/logs/_read":
+		handler.readElasticLogFile(recorder, req, nil)
+	default:
+		if shouldServeRegisteredAPIReverse(method, requestPath) {
+			return executeAgentRegisteredAPIReverse(method, requestPath, body, reqMsg)
+		}
 		recorder.WriteHeader(http.StatusNotFound)
 		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))
 	}
@@ -263,6 +307,120 @@ func executeAgentReverseRequest(method, requestPath string, body []byte, reqMsg 
 		responseBody = buildAgentReverseErrorBody(status, http.StatusText(status))
 	}
 	return status, responseBody
+}
+
+func executeAgentRegisteredAPIReverse(method, requestPath string, body []byte, reqMsg framework_reverse.RequestMessage) (status int, responseBody []byte) {
+	target, err := agentReverseAPIProxyTargetResolver()
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+
+	proxyURL, err := buildAgentReverseProxyURL(target.endpoint, target.basePath, requestPath)
+	if err != nil {
+		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+	}
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, proxyURL, bodyReader)
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+	reqMsg.ApplyHeaders(req)
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", util.ContentTypeJson)
+	}
+	if target.basicAuthUser != "" {
+		req.SetBasicAuth(target.basicAuthUser, target.basicAuthPass)
+	}
+
+	client, err := agentReverseHTTPClientFactory(target)
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+	result, err := client.Do(req)
+	if err != nil {
+		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
+	}
+	defer result.Body.Close()
+
+	responseBody, _ = io.ReadAll(result.Body)
+	status = result.StatusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if len(responseBody) == 0 && status >= http.StatusBadRequest {
+		responseBody = buildAgentReverseErrorBody(status, http.StatusText(status))
+	}
+	return status, responseBody
+}
+
+func resolveAgentReverseAPIProxyTarget() (agentReverseProxyTarget, error) {
+	apiCfg := global.Env().SystemConfig.APIConfig
+	if apiCfg.Enabled {
+		return agentReverseProxyTarget{
+			endpoint:      apiCfg.GetEndpoint(),
+			basePath:      apiCfg.BasePath,
+			tlsConfig:     apiCfg.TLSConfig,
+			basicAuthUser: apiCfg.Security.Username,
+			basicAuthPass: apiCfg.Security.Password,
+		}, nil
+	}
+
+	webCfg := global.Env().SystemConfig.WebAppConfig
+	if webCfg.Enabled && webCfg.EmbeddingAPI {
+		return agentReverseProxyTarget{
+			endpoint:  webCfg.GetEndpoint(),
+			basePath:  webCfg.BasePath,
+			tlsConfig: webCfg.TLSConfig,
+		}, nil
+	}
+	return agentReverseProxyTarget{}, fmt.Errorf("reverse channel api endpoint unavailable")
+}
+
+func buildAgentReverseProxyURL(endpoint, basePath, requestPath string) (string, error) {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(requestPath))
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(endpoint) == "" {
+		return "", fmt.Errorf("reverse channel endpoint unavailable")
+	}
+
+	fullPath := parsed.Path
+	basePath = strings.TrimSpace(basePath)
+	if basePath != "" && basePath != "/" {
+		if !strings.HasPrefix(basePath, "/") {
+			basePath = "/" + basePath
+		}
+		fullPath = strings.TrimRight(basePath, "/") + fullPath
+	}
+
+	proxyURL := strings.TrimRight(strings.TrimSpace(endpoint), "/") + fullPath
+	if parsed.RawQuery != "" {
+		proxyURL += "?" + parsed.RawQuery
+	}
+	return proxyURL, nil
+}
+
+func newAgentReverseHTTPClient(target agentReverseProxyTarget) (*http.Client, error) {
+	transport := &http.Transport{}
+	if target.tlsConfig.TLSEnabled {
+		tlsCfg := target.tlsConfig
+		tlsCfg.SkipDomainVerify = true
+		clientTLSConfig, err := api.GetClientTLSConfig(&tlsCfg)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = clientTLSConfig
+	}
+
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: transport,
+	}, nil
 }
 
 func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte) error {

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -104,8 +104,16 @@ func connectAndServeAgentReverseChannel() error {
 func getAgentReverseChannelServers() []string {
 	agentCfg := configcommon.GetAgentConfig()
 	if agentCfg != nil && agentCfg.Setup != nil {
-		if endpoint := strings.TrimSpace(agentCfg.Setup.ReverseChannelEndpoint); endpoint != "" {
-			return []string{endpoint}
+		servers := make([]string, 0, len(agentCfg.Setup.ReverseChannelEndpoints))
+		for _, endpoint := range agentCfg.Setup.ReverseChannelEndpoints {
+			endpoint = strings.TrimSpace(endpoint)
+			if endpoint == "" {
+				continue
+			}
+			servers = append(servers, endpoint)
+		}
+		if len(servers) > 0 {
+			return servers
 		}
 	}
 

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -29,14 +29,17 @@ import (
 )
 
 const (
-	agentReverseChannelHeaderInstanceID = "X-INFINI-INSTANCE-ID"
-	agentReverseHelloCommand            = "agent_reverse_hello"
-	agentReverseRequestCommand          = "agent_reverse_request"
-	agentReverseResponseCommand         = "agent_reverse_response"
-	agentReverseChannelTag              = "agent_reverse_channel"
-	agentReverseReconnectDelay          = 5 * time.Second
-	agentReverseMaxIncomingMessageBytes = 8 * 1024 * 1024
-	agentReverseResponseChunkBytes      = 32 * 1024
+	reverseChannelHeaderInstanceID = "X-INFINI-INSTANCE-ID"
+	reverseHelloCommand            = "reverse_hello"
+	reverseRequestCommand          = "reverse_request"
+	reverseResponseCommand         = "reverse_response"
+	legacyReverseHelloCommand      = "agent_reverse_hello"
+	legacyReverseRequestCommand    = "agent_reverse_request"
+	legacyReverseResponseCommand   = "agent_reverse_response"
+	reverseChannelTag              = "agent_reverse_channel"
+	reverseReconnectDelay          = 5 * time.Second
+	reverseMaxIncomingMessageBytes = 8 * 1024 * 1024
+	reverseResponseChunkBytes      = 32 * 1024
 )
 
 type agentReverseHelloMessage struct {
@@ -83,9 +86,9 @@ func shouldServeRegisteredAPIReverse(method, rawPath string) bool {
 
 func registerAgentReverseChannel() {
 	global.RegisterBackgroundCallback(&global.BackgroundTask{
-		Tag:          agentReverseChannelTag,
-		Interval:     agentReverseReconnectDelay,
-		InitialDelay: agentReverseReconnectDelay,
+		Tag:          reverseChannelTag,
+		Interval:     reverseReconnectDelay,
+		InitialDelay: reverseReconnectDelay,
 		Func:         ensureAgentReverseChannel,
 	})
 }
@@ -112,7 +115,7 @@ func runAgentReverseChannel() {
 		if global.ShuttingDown() {
 			return
 		}
-		time.Sleep(agentReverseReconnectDelay)
+		time.Sleep(reverseReconnectDelay)
 	}
 }
 
@@ -125,7 +128,7 @@ func connectAndServeAgentReverseChannel() error {
 			continue
 		}
 		defer conn.Close()
-		conn.SetReadLimit(agentReverseMaxIncomingMessageBytes)
+		conn.SetReadLimit(reverseMaxIncomingMessageBytes)
 
 		for {
 			messageType, payload, err := conn.ReadMessage()
@@ -170,7 +173,7 @@ func dialAgentReverseChannel(server string) (*websocket.Conn, error) {
 	}
 
 	headers := http.Header{}
-	headers.Set(agentReverseChannelHeaderInstanceID, global.Env().SystemConfig.NodeConfig.ID)
+	headers.Set(reverseChannelHeaderInstanceID, global.Env().SystemConfig.NodeConfig.ID)
 	managerToken, err := configcommon.LoadTokenFromKeystore(configcommon.ManagerTokenKeystoreKey)
 	if err != nil {
 		return nil, err
@@ -222,30 +225,48 @@ func handleAgentReverseChannelMessage(conn *websocket.Conn, payload []byte) {
 		if strings.HasPrefix(parts[1], "websocket-session-id:") {
 			sessionID := strings.TrimSpace(strings.TrimPrefix(parts[1], "websocket-session-id:"))
 			if sessionID != "" {
-				_ = writeAgentReverseText(conn, agentReverseHelloCommand+" "+string(util.MustToJSONBytes(agentReverseHelloMessage{
+				helloPayload := string(util.MustToJSONBytes(agentReverseHelloMessage{
 					SessionID:  sessionID,
 					InstanceID: global.Env().SystemConfig.NodeConfig.ID,
-				})))
+				}))
+				_ = writeAgentReverseText(conn, reverseHelloCommand+" "+helloPayload)
+				_ = writeAgentReverseText(conn, legacyReverseHelloCommand+" "+helloPayload)
 			}
 		}
 	case "PRIVATE":
-		prefix := agentReverseRequestCommand + " "
-		if strings.HasPrefix(parts[1], prefix) {
-			go handleAgentReverseRequest(conn, strings.TrimPrefix(parts[1], prefix))
+		if command, body, ok := matchReverseRequestCommand(parts[1]); ok {
+			go handleAgentReverseRequest(conn, strings.TrimPrefix(parts[1], body), command)
 		}
 	}
 }
 
-func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
+func matchReverseRequestCommand(payload string) (command, prefix string, ok bool) {
+	for _, candidate := range []string{reverseRequestCommand, legacyReverseRequestCommand} {
+		prefix = candidate + " "
+		if strings.HasPrefix(payload, prefix) {
+			return candidate, prefix, true
+		}
+	}
+	return "", "", false
+}
+
+func responseCommandForRequest(command string) string {
+	if command == legacyReverseRequestCommand {
+		return legacyReverseResponseCommand
+	}
+	return reverseResponseCommand
+}
+
+func handleAgentReverseRequest(conn *websocket.Conn, payload string, requestCommand string) {
 	reqMsg := agentReverseRequestMessage{}
 	if err := util.FromJSONBytes([]byte(payload), &reqMsg); err != nil {
 		body := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
-		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body, responseCommandForRequest(requestCommand))
 		return
 	}
 	if !validateAgentAccessToken(reqMsg.AccessToken) {
 		body := buildAgentReverseErrorBody(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
-		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusUnauthorized, body)
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusUnauthorized, body, responseCommandForRequest(requestCommand))
 		return
 	}
 
@@ -254,14 +275,14 @@ func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
 		decoded, err := base64.StdEncoding.DecodeString(reqMsg.Body)
 		if err != nil {
 			errBody := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
-			_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusBadRequest, errBody)
+			_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusBadRequest, errBody, responseCommandForRequest(requestCommand))
 			return
 		}
 		body = decoded
 	}
 
 	status, responseBody := executeAgentReverseRequest(reqMsg.Method, reqMsg.Path, body)
-	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, status, responseBody)
+	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, status, responseBody, responseCommandForRequest(requestCommand))
 }
 
 func executeAgentReverseRequest(method, requestPath string, body []byte) (status int, responseBody []byte) {
@@ -318,9 +339,9 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 	return status, responseBody
 }
 
-func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte) error {
-	for start := 0; start < len(body); start += agentReverseResponseChunkBytes {
-		end := start + agentReverseResponseChunkBytes
+func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte, command string) error {
+	for start := 0; start < len(body); start += reverseResponseChunkBytes {
+		end := start + reverseResponseChunkBytes
 		if end > len(body) {
 			end = len(body)
 		}
@@ -329,7 +350,7 @@ func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID strin
 			InstanceID: instanceID,
 			Chunk:      base64.StdEncoding.EncodeToString(body[start:end]),
 		}
-		if err := writeAgentReverseText(conn, agentReverseResponseCommand+" "+string(util.MustToJSONBytes(msg))); err != nil {
+		if err := writeAgentReverseText(conn, command+" "+string(util.MustToJSONBytes(msg))); err != nil {
 			return err
 		}
 	}
@@ -340,7 +361,7 @@ func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID strin
 		Status:     status,
 		Done:       true,
 	}
-	return writeAgentReverseText(conn, agentReverseResponseCommand+" "+string(util.MustToJSONBytes(doneMsg)))
+	return writeAgentReverseText(conn, command+" "+string(util.MustToJSONBytes(doneMsg)))
 }
 
 func writeAgentReverseText(conn *websocket.Conn, payload string) error {

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -35,7 +35,7 @@ const (
 	agentReverseResponseCommand         = "agent_reverse_response"
 	agentReverseChannelTag              = "agent_reverse_channel"
 	agentReverseReconnectDelay          = 5 * time.Second
-	agentReverseMaxIncomingMessageBytes = 1024 * 1024
+	agentReverseMaxIncomingMessageBytes = 8 * 1024 * 1024
 	agentReverseResponseChunkBytes      = 32 * 1024
 )
 

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -22,7 +22,6 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/websocket"
 	"infini.sh/framework/core/api"
-	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 	configcommon "infini.sh/framework/modules/configs/common"
@@ -63,23 +62,7 @@ type agentReverseResponseMessage struct {
 
 var agentReverseChannelRunning atomic.Bool
 var agentReverseChannelWriteLock sync.Mutex
-var agentReverseAPIPathMatcher = newAgentReverseAPIPathMatcher()
-
-func newAgentReverseAPIPathMatcher() *httprouter.Router {
-	router := httprouter.New(nil)
-	handle := func(http.ResponseWriter, *http.Request, httprouter.Params) {}
-	registerProtectedAPIRoutes(router, handle)
-	return router
-}
-
-func shouldServeRegisteredAPIReverse(method, rawPath string) bool {
-	parsed, err := url.ParseRequestURI(strings.TrimSpace(rawPath))
-	if err != nil || parsed.Path == "" {
-		return false
-	}
-	handle, _, _ := agentReverseAPIPathMatcher.Lookup(strings.ToUpper(method), parsed.Path)
-	return handle != nil
-}
+var agentReverseAPIs = newReverseAPIRouter(AgentAPI{})
 
 func registerAgentReverseChannel() {
 	global.RegisterBackgroundCallback(&global.BackgroundTask{
@@ -280,28 +263,11 @@ func executeAgentReverseRequest(method, requestPath string, body []byte) (status
 	req := httptest.NewRequest(method, "http://agent"+requestPath, bodyReader)
 	req.Header.Set("Content-Type", util.ContentTypeJson)
 	recorder := httptest.NewRecorder()
-	handler := AgentAPI{}
-	parsedPath, err := url.ParseRequestURI(requestPath)
-	if err != nil {
+	if _, err := url.ParseRequestURI(requestPath); err != nil {
 		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
 	}
 
-	switch parsedPath.Path {
-	case "/agent/_info":
-		handler.getAgentInfo(recorder, req, nil)
-	case "/elasticsearch/node/_discovery":
-		handler.getESNodes(recorder, req, nil)
-	case "/elasticsearch/node/_info":
-		handler.getESNodeInfo(recorder, req, nil)
-	case "/elasticsearch/logs/_list":
-		handler.getElasticLogFiles(recorder, req, nil)
-	case "/elasticsearch/logs/_read":
-		handler.readElasticLogFile(recorder, req, nil)
-	default:
-		if shouldServeRegisteredAPIReverse(method, requestPath) {
-			api.ServeRegisteredAPIRequest(recorder, req)
-			break
-		}
+	if !agentReverseAPIs.ServeHTTP(recorder, req) {
 		recorder.WriteHeader(http.StatusNotFound)
 		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))
 	}

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -1,0 +1,298 @@
+/* Copyright © INFINI Ltd. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/gorilla/websocket"
+	"infini.sh/framework/core/api"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/util"
+)
+
+const (
+	agentReverseChannelHeaderInstanceID = "X-INFINI-INSTANCE-ID"
+	agentReverseHelloCommand            = "agent_reverse_hello"
+	agentReverseRequestCommand          = "agent_reverse_request"
+	agentReverseResponseCommand         = "agent_reverse_response"
+	agentReverseChannelTag              = "agent_reverse_channel"
+	agentReverseReconnectDelay          = 5 * time.Second
+	agentReverseMaxIncomingMessageBytes = 1024 * 1024
+	agentReverseResponseChunkBytes      = 160
+)
+
+type agentReverseHelloMessage struct {
+	SessionID  string `json:"session_id"`
+	InstanceID string `json:"instance_id"`
+}
+
+type agentReverseRequestMessage struct {
+	RequestID  string `json:"request_id"`
+	InstanceID string `json:"instance_id"`
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	Body       string `json:"body,omitempty"`
+}
+
+type agentReverseResponseMessage struct {
+	RequestID  string `json:"request_id"`
+	InstanceID string `json:"instance_id"`
+	Chunk      string `json:"chunk,omitempty"`
+	Status     int    `json:"status,omitempty"`
+	Done       bool   `json:"done,omitempty"`
+}
+
+var agentReverseChannelRunning atomic.Bool
+var agentReverseChannelWriteLock sync.Mutex
+
+func registerAgentReverseChannel() {
+	global.RegisterBackgroundCallback(&global.BackgroundTask{
+		Tag:          agentReverseChannelTag,
+		Interval:     agentReverseReconnectDelay,
+		InitialDelay: agentReverseReconnectDelay,
+		Func:         ensureAgentReverseChannel,
+	})
+}
+
+func ensureAgentReverseChannel() {
+	if global.ShuttingDown() || !global.Env().SystemConfig.Configs.Managed || len(global.Env().SystemConfig.Configs.Servers) == 0 {
+		return
+	}
+	if !agentReverseChannelRunning.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer agentReverseChannelRunning.Store(false)
+		runAgentReverseChannel()
+	}()
+}
+
+func runAgentReverseChannel() {
+	for !global.ShuttingDown() {
+		err := connectAndServeAgentReverseChannel()
+		if err != nil && !global.ShuttingDown() {
+			log.Warnf("agent reverse channel disconnected: %v", err)
+		}
+		if global.ShuttingDown() {
+			return
+		}
+		time.Sleep(agentReverseReconnectDelay)
+	}
+}
+
+func connectAndServeAgentReverseChannel() error {
+	var lastErr error
+	for _, server := range global.Env().SystemConfig.Configs.Servers {
+		conn, err := dialAgentReverseChannel(server)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		defer conn.Close()
+		conn.SetReadLimit(agentReverseMaxIncomingMessageBytes)
+
+		for {
+			messageType, payload, err := conn.ReadMessage()
+			if err != nil {
+				return err
+			}
+			if messageType != websocket.TextMessage {
+				continue
+			}
+			handleAgentReverseChannelMessage(conn, payload)
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("no console server available for agent reverse channel")
+}
+
+func dialAgentReverseChannel(server string) (*websocket.Conn, error) {
+	wsURL, err := buildAgentReverseChannelURL(server)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := http.Header{}
+	headers.Set(agentReverseChannelHeaderInstanceID, global.Env().SystemConfig.NodeConfig.ID)
+	managerAuth := global.Env().SystemConfig.Configs.ManagerConfig.BasicAuth
+	if managerAuth.Username != "" {
+		token := base64.StdEncoding.EncodeToString([]byte(managerAuth.Username + ":" + managerAuth.Password.Get()))
+		headers.Set("Authorization", "Basic "+token)
+	}
+
+	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	if clientCfg := global.Env().GetHTTPClientConfig("configs", server); clientCfg != nil {
+		tlsCfg, err := api.GetClientTLSConfig(&clientCfg.TLSConfig)
+		if err != nil {
+			return nil, err
+		}
+		dialer.TLSClientConfig = tlsCfg
+	}
+	conn, _, err := dialer.Dial(wsURL, headers)
+	return conn, err
+}
+
+func buildAgentReverseChannelURL(server string) (string, error) {
+	parsed, err := url.Parse(server)
+	if err != nil {
+		return "", err
+	}
+	switch parsed.Scheme {
+	case "https":
+		parsed.Scheme = "wss"
+	default:
+		parsed.Scheme = "ws"
+	}
+	parsed.Path = path.Join(parsed.Path, "/ws")
+	return parsed.String(), nil
+}
+
+func handleAgentReverseChannelMessage(conn *websocket.Conn, payload []byte) {
+	text := string(payload)
+	parts := strings.SplitN(text, " ", 2)
+	if len(parts) != 2 {
+		return
+	}
+
+	switch parts[0] {
+	case "CONFIG":
+		if strings.HasPrefix(parts[1], "websocket-session-id:") {
+			sessionID := strings.TrimSpace(strings.TrimPrefix(parts[1], "websocket-session-id:"))
+			if sessionID != "" {
+				_ = writeAgentReverseText(conn, agentReverseHelloCommand+" "+string(util.MustToJSONBytes(agentReverseHelloMessage{
+					SessionID:  sessionID,
+					InstanceID: global.Env().SystemConfig.NodeConfig.ID,
+				})))
+			}
+		}
+	case "PRIVATE":
+		prefix := agentReverseRequestCommand + " "
+		if strings.HasPrefix(parts[1], prefix) {
+			go handleAgentReverseRequest(conn, strings.TrimPrefix(parts[1], prefix))
+		}
+	}
+}
+
+func handleAgentReverseRequest(conn *websocket.Conn, payload string) {
+	reqMsg := agentReverseRequestMessage{}
+	if err := util.FromJSONBytes([]byte(payload), &reqMsg); err != nil {
+		body := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+		_ = writeAgentReverseResponse(conn, reqMsg.RequestID, global.Env().SystemConfig.NodeConfig.ID, http.StatusBadRequest, body)
+		return
+	}
+
+	body := []byte(nil)
+	if reqMsg.Body != "" {
+		decoded, err := base64.StdEncoding.DecodeString(reqMsg.Body)
+		if err != nil {
+			errBody := buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
+			_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, http.StatusBadRequest, errBody)
+			return
+		}
+		body = decoded
+	}
+
+	status, responseBody := executeAgentReverseRequest(reqMsg.Method, reqMsg.Path, body)
+	_ = writeAgentReverseResponse(conn, reqMsg.RequestID, reqMsg.InstanceID, status, responseBody)
+}
+
+func executeAgentReverseRequest(method, requestPath string, body []byte) (status int, responseBody []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			status = http.StatusInternalServerError
+			responseBody = buildAgentReverseErrorBody(status, fmt.Sprint(r))
+		}
+	}()
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, "http://agent"+requestPath, bodyReader)
+	req.Header.Set("Content-Type", util.ContentTypeJson)
+	recorder := httptest.NewRecorder()
+	handler := AgentAPI{}
+
+	switch requestPath {
+	case "/elasticsearch/node/_discovery":
+		handler.getESNodes(recorder, req, nil)
+	case "/elasticsearch/node/_info":
+		handler.getESNodeInfo(recorder, req, nil)
+	case "/elasticsearch/logs/_list":
+		handler.getElasticLogFiles(recorder, req, nil)
+	case "/elasticsearch/logs/_read":
+		handler.readElasticLogFile(recorder, req, nil)
+	default:
+		recorder.WriteHeader(http.StatusNotFound)
+		recorder.Write(buildAgentReverseErrorBody(http.StatusNotFound, "reverse channel path not found"))
+	}
+
+	result := recorder.Result()
+	defer result.Body.Close()
+	responseBody, _ = io.ReadAll(result.Body)
+	status = result.StatusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if len(responseBody) == 0 && status >= http.StatusBadRequest {
+		responseBody = buildAgentReverseErrorBody(status, http.StatusText(status))
+	}
+	return status, responseBody
+}
+
+func writeAgentReverseResponse(conn *websocket.Conn, requestID, instanceID string, status int, body []byte) error {
+	for start := 0; start < len(body); start += agentReverseResponseChunkBytes {
+		end := start + agentReverseResponseChunkBytes
+		if end > len(body) {
+			end = len(body)
+		}
+		msg := agentReverseResponseMessage{
+			RequestID:  requestID,
+			InstanceID: instanceID,
+			Chunk:      base64.StdEncoding.EncodeToString(body[start:end]),
+		}
+		if err := writeAgentReverseText(conn, agentReverseResponseCommand+" "+string(util.MustToJSONBytes(msg))); err != nil {
+			return err
+		}
+	}
+
+	doneMsg := agentReverseResponseMessage{
+		RequestID:  requestID,
+		InstanceID: instanceID,
+		Status:     status,
+		Done:       true,
+	}
+	return writeAgentReverseText(conn, agentReverseResponseCommand+" "+string(util.MustToJSONBytes(doneMsg)))
+}
+
+func writeAgentReverseText(conn *websocket.Conn, payload string) error {
+	agentReverseChannelWriteLock.Lock()
+	defer agentReverseChannelWriteLock.Unlock()
+	return conn.WriteMessage(websocket.TextMessage, []byte(payload))
+}
+
+func buildAgentReverseErrorBody(status int, reason string) []byte {
+	return util.MustToJSONBytes(util.MapStr{
+		"error": util.MapStr{
+			"reason": reason,
+		},
+		"status": status,
+	})
+}

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -49,6 +49,8 @@ var agentReverseChannelWriteLock sync.Mutex
 var agentReverseAPIPathMatcher = newAgentReverseAPIPathMatcher()
 var agentReverseAPIProxyTargetResolver = resolveAgentReverseAPIProxyTarget
 var agentReverseHTTPClientFactory = newAgentReverseHTTPClient
+var agentReverseStateLock sync.Mutex
+var agentReverseLastState string
 
 func newAgentReverseAPIPathMatcher() *httprouter.Router {
 	router := httprouter.New(nil)
@@ -76,12 +78,23 @@ func registerAgentReverseChannel() {
 }
 
 func ensureAgentReverseChannel() {
-	if global.ShuttingDown() || !global.Env().SystemConfig.Configs.Managed || len(getAgentReverseChannelServers()) == 0 {
+	if global.ShuttingDown() {
+		logAgentReverseStatef("shutting-down", "skip agent reverse channel startup: application is shutting down")
+		return
+	}
+	if !global.Env().SystemConfig.Configs.Managed {
+		logAgentReverseStatef("configs-unmanaged", "skip agent reverse channel startup: configs.managed is disabled")
+		return
+	}
+	servers := getAgentReverseChannelServers()
+	if len(servers) == 0 {
+		logAgentReverseStatef("no-endpoints", "skip agent reverse channel startup: no reverse channel endpoints configured")
 		return
 	}
 	if !agentReverseChannelRunning.CompareAndSwap(false, true) {
 		return
 	}
+	logAgentReverseStatef("starting", "starting agent reverse channel with endpoints: %s", strings.Join(servers, ", "))
 	go func() {
 		defer agentReverseChannelRunning.Store(false)
 		runAgentReverseChannel()
@@ -104,11 +117,14 @@ func runAgentReverseChannel() {
 func connectAndServeAgentReverseChannel() error {
 	var lastErr error
 	for _, server := range getAgentReverseChannelServers() {
+		log.Debugf("attempting agent reverse channel connection to [%s]", server)
 		conn, err := dialAgentReverseChannel(server)
 		if err != nil {
+			log.Debugf("failed to dial agent reverse channel endpoint [%s]: %v", server, err)
 			lastErr = err
 			continue
 		}
+		logAgentReverseStatef("connected:"+server, "agent reverse channel connected to [%s]", server)
 		defer conn.Close()
 		conn.SetReadLimit(agentReverseMaxIncomingMessageBytes)
 
@@ -215,10 +231,16 @@ func handleAgentReverseChannelMessage(conn *websocket.Conn, payload []byte) {
 		if strings.HasPrefix(parts[1], "websocket-session-id:") {
 			sessionID := strings.TrimSpace(strings.TrimPrefix(parts[1], "websocket-session-id:"))
 			if sessionID != "" {
-				_ = writeAgentReverseText(conn, framework_reverse.FormatHelloCommand(framework_reverse.HelloMessage{
+				log.Debugf("agent reverse channel received websocket session id [%s]", sessionID)
+				err := writeAgentReverseText(conn, framework_reverse.FormatHelloCommand(framework_reverse.HelloMessage{
 					SessionID: sessionID,
 					PeerID:    global.Env().SystemConfig.NodeConfig.ID,
 				}))
+				if err != nil {
+					log.Warnf("failed to send agent reverse hello for session [%s]: %v", sessionID, err)
+					return
+				}
+				log.Infof("agent reverse channel handshake sent for session [%s]", sessionID)
 			}
 		}
 	case "PRIVATE":
@@ -312,11 +334,13 @@ func executeAgentReverseRequest(method, requestPath string, body []byte, reqMsg 
 func executeAgentRegisteredAPIReverse(method, requestPath string, body []byte, reqMsg framework_reverse.RequestMessage) (status int, responseBody []byte) {
 	target, err := agentReverseAPIProxyTargetResolver()
 	if err != nil {
+		log.Warnf("agent reverse channel cannot proxy request [%s %s]: %v", method, requestPath, err)
 		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
 	}
 
 	proxyURL, err := buildAgentReverseProxyURL(target.endpoint, target.basePath, requestPath)
 	if err != nil {
+		log.Warnf("agent reverse channel cannot build proxy URL for [%s %s]: %v", method, requestPath, err)
 		return http.StatusBadRequest, buildAgentReverseErrorBody(http.StatusBadRequest, err.Error())
 	}
 
@@ -338,10 +362,12 @@ func executeAgentRegisteredAPIReverse(method, requestPath string, body []byte, r
 
 	client, err := agentReverseHTTPClientFactory(target)
 	if err != nil {
+		log.Warnf("agent reverse channel cannot build HTTP client for [%s %s]: %v", method, requestPath, err)
 		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
 	}
 	result, err := client.Do(req)
 	if err != nil {
+		log.Warnf("agent reverse channel proxy request failed [%s %s -> %s]: %v", method, requestPath, proxyURL, err)
 		return http.StatusBadGateway, buildAgentReverseErrorBody(http.StatusBadGateway, err.Error())
 	}
 	defer result.Body.Close()
@@ -450,4 +476,14 @@ func validateAgentAccessToken(tokenValue string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(expected), []byte(tokenValue)) == 1
+}
+
+func logAgentReverseStatef(state string, format string, args ...interface{}) {
+	agentReverseStateLock.Lock()
+	defer agentReverseStateLock.Unlock()
+	if state == agentReverseLastState {
+		return
+	}
+	agentReverseLastState = state
+	log.Infof(format, args...)
 }

--- a/plugin/api/reverse_channel.go
+++ b/plugin/api/reverse_channel.go
@@ -24,6 +24,7 @@ import (
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
+	configcommon "infini.sh/framework/modules/configs/common"
 )
 
 const (
@@ -65,33 +66,7 @@ var agentReverseAPIPathMatcher = newAgentReverseAPIPathMatcher()
 func newAgentReverseAPIPathMatcher() *httprouter.Router {
 	router := httprouter.New(nil)
 	handle := func(http.ResponseWriter, *http.Request, httprouter.Params) {}
-	routes := []struct {
-		method string
-		path   string
-	}{
-		{http.MethodGet, "/stats"},
-		{http.MethodGet, "/queue/stats"},
-		{http.MethodGet, "/queue/:id/stats"},
-		{http.MethodGet, "/queue/:id/_scroll"},
-		{http.MethodDelete, "/queue/:id"},
-		{http.MethodDelete, "/queue/_search"},
-		{http.MethodPut, "/queue/:id/consumer/:consumer_id/offset"},
-		{http.MethodGet, "/queue/:id/consumer/:consumer_id/offset"},
-		{http.MethodDelete, "/queue/:id/consumer/:consumer_id"},
-		{http.MethodDelete, "/queue/consumer/_search"},
-		{http.MethodGet, "/pipeline/tasks/"},
-		{http.MethodPost, "/pipeline/tasks/_search"},
-		{http.MethodPost, "/pipeline/task/:id/_start"},
-		{http.MethodPost, "/pipeline/task/:id/_stop"},
-		{http.MethodGet, "/pipeline/task/:id"},
-		{http.MethodDelete, "/pipeline/task/:id"},
-		{http.MethodGet, "/config/"},
-		{http.MethodPut, "/config/"},
-		{http.MethodGet, "/config/runtime"},
-	}
-	for _, route := range routes {
-		router.Handle(route.method, route.path, handle)
-	}
+	registerProtectedAPIRoutes(router, handle)
 	return router
 }
 
@@ -114,7 +89,7 @@ func registerAgentReverseChannel() {
 }
 
 func ensureAgentReverseChannel() {
-	if global.ShuttingDown() || !global.Env().SystemConfig.Configs.Managed || len(global.Env().SystemConfig.Configs.Servers) == 0 {
+	if global.ShuttingDown() || !global.Env().SystemConfig.Configs.Managed || len(getAgentReverseChannelServers()) == 0 {
 		return
 	}
 	if !agentReverseChannelRunning.CompareAndSwap(false, true) {
@@ -141,7 +116,7 @@ func runAgentReverseChannel() {
 
 func connectAndServeAgentReverseChannel() error {
 	var lastErr error
-	for _, server := range global.Env().SystemConfig.Configs.Servers {
+	for _, server := range getAgentReverseChannelServers() {
 		conn, err := dialAgentReverseChannel(server)
 		if err != nil {
 			lastErr = err
@@ -165,6 +140,25 @@ func connectAndServeAgentReverseChannel() error {
 		return lastErr
 	}
 	return fmt.Errorf("no console server available for agent reverse channel")
+}
+
+func getAgentReverseChannelServers() []string {
+	agentCfg := configcommon.GetAgentConfig()
+	if agentCfg != nil && agentCfg.Setup != nil {
+		if endpoint := strings.TrimSpace(agentCfg.Setup.ReverseChannelEndpoint); endpoint != "" {
+			return []string{endpoint}
+		}
+	}
+
+	servers := make([]string, 0, len(global.Env().SystemConfig.Configs.Servers))
+	for _, server := range global.Env().SystemConfig.Configs.Servers {
+		server = strings.TrimSpace(server)
+		if server == "" {
+			continue
+		}
+		servers = append(servers, server)
+	}
+	return servers
 }
 
 func dialAgentReverseChannel(server string) (*websocket.Conn, error) {

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
 )
 
 func TestBuildAgentReverseChannelURL(t *testing.T) {
@@ -46,22 +49,55 @@ func TestExecuteAgentReverseRequestUnknownPath(t *testing.T) {
 	}
 }
 
-func TestShouldServeRegisteredAPIReverse(t *testing.T) {
+func TestProtectedAPIRouter(t *testing.T) {
+	router := newProtectedAPIRouter(func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	t.Run("match and serve protected route", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/queue/stats?size=20", nil)
+		if !router.Match(req.Method, req.URL.RequestURI()) {
+			t.Fatal("expected protected route to match")
+		}
+		recorder := httptest.NewRecorder()
+		if !router.ServeHTTP(recorder, req) {
+			t.Fatal("expected protected route to be served")
+		}
+		if recorder.Code != http.StatusAccepted {
+			t.Fatalf("unexpected status code: %d", recorder.Code)
+		}
+	})
+
+	t.Run("reject unknown route", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/not-found", nil)
+		if router.Match(req.Method, req.URL.RequestURI()) {
+			t.Fatal("expected unknown route not to match")
+		}
+		recorder := httptest.NewRecorder()
+		if router.ServeHTTP(recorder, req) {
+			t.Fatal("expected unknown route not to be served")
+		}
+	})
+}
+
+func TestReverseAPIRouterMatchesSpecialAndProtectedRoutes(t *testing.T) {
+	router := newReverseAPIRouter(AgentAPI{})
+
 	testCases := []struct {
 		name   string
 		method string
 		path   string
 		expect bool
 	}{
-		{name: "queue stats", method: http.MethodGet, path: "/queue/stats", expect: true},
-		{name: "task search with query", method: http.MethodGet, path: "/pipeline/tasks/?size=20", expect: true},
-		{name: "config runtime", method: http.MethodGet, path: "/config/runtime", expect: true},
-		{name: "logger setting", method: http.MethodPost, path: "/setting/logger", expect: true},
+		{name: "agent info", method: http.MethodGet, path: "/agent/_info", expect: true},
+		{name: "discovery", method: http.MethodGet, path: "/elasticsearch/node/_discovery", expect: true},
+		{name: "protected queue route", method: http.MethodGet, path: "/queue/stats", expect: true},
+		{name: "unknown route", method: http.MethodGet, path: "/not-found", expect: false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if actual := shouldServeRegisteredAPIReverse(tc.method, tc.path); actual != tc.expect {
+			if actual := router.Match(tc.method, tc.path); actual != tc.expect {
 				t.Fatalf("unexpected match result: %v", actual)
 			}
 		})

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	httprouter "infini.sh/framework/core/api/router"
 	framework_reverse "infini.sh/framework/core/api/websocket/reverse"
+	"infini.sh/framework/core/global"
 )
 
 func TestBuildAgentReverseChannelURL(t *testing.T) {
@@ -102,5 +104,87 @@ func TestReverseAPIRouterMatchesSpecialAndProtectedRoutes(t *testing.T) {
 				t.Fatalf("unexpected match result: %v", actual)
 			}
 		})
+	}
+}
+
+func TestExecuteAgentRegisteredAPIReverse(t *testing.T) {
+	oldResolver := agentReverseAPIProxyTargetResolver
+	oldClientFactory := agentReverseHTTPClientFactory
+	t.Cleanup(func() {
+		agentReverseAPIProxyTargetResolver = oldResolver
+		agentReverseHTTPClientFactory = oldClientFactory
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		user, password, ok := req.BasicAuth()
+		if !ok || user != "api-user" || password != "api-pass" {
+			t.Fatalf("unexpected basic auth: %v %s %s", ok, user, password)
+		}
+		if req.URL.Path != "/api/queue/stats" || req.URL.RawQuery != "size=20" {
+			t.Fatalf("unexpected proxied url: %s", req.URL.String())
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer server.Close()
+
+	agentReverseAPIProxyTargetResolver = func() (agentReverseProxyTarget, error) {
+		return agentReverseProxyTarget{
+			endpoint:      server.URL,
+			basePath:      "/api",
+			basicAuthUser: "api-user",
+			basicAuthPass: "api-pass",
+		}, nil
+	}
+	agentReverseHTTPClientFactory = func(agentReverseProxyTarget) (*http.Client, error) {
+		return server.Client(), nil
+	}
+
+	status, body := executeAgentRegisteredAPIReverse(http.MethodGet, "/queue/stats?size=20", nil, framework_reverse.RequestMessage{})
+	if status != http.StatusAccepted {
+		t.Fatalf("unexpected status: %d", status)
+	}
+	if string(body) != "proxied" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestResolveAgentReverseAPIProxyTarget(t *testing.T) {
+	oldAPIConfig := global.Env().SystemConfig.APIConfig
+	oldWebConfig := global.Env().SystemConfig.WebAppConfig
+	t.Cleanup(func() {
+		global.Env().SystemConfig.APIConfig = oldAPIConfig
+		global.Env().SystemConfig.WebAppConfig = oldWebConfig
+	})
+
+	apiURL, _ := url.Parse("http://127.0.0.1:9000")
+	global.Env().SystemConfig.APIConfig.Enabled = true
+	global.Env().SystemConfig.APIConfig.NetworkConfig.Publish = apiURL.Host
+	global.Env().SystemConfig.APIConfig.BasePath = "/api"
+	global.Env().SystemConfig.APIConfig.Security.Username = "api-user"
+	global.Env().SystemConfig.APIConfig.Security.Password = "api-pass"
+
+	target, err := resolveAgentReverseAPIProxyTarget()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target.endpoint != "http://"+apiURL.Host {
+		t.Fatalf("unexpected endpoint: %s", target.endpoint)
+	}
+	if target.basePath != "/api" {
+		t.Fatalf("unexpected base path: %s", target.basePath)
+	}
+	if target.basicAuthUser != "api-user" || target.basicAuthPass != "api-pass" {
+		t.Fatalf("unexpected auth target: %#v", target)
+	}
+}
+
+func TestBuildAgentReverseProxyURL(t *testing.T) {
+	actual, err := buildAgentReverseProxyURL("http://127.0.0.1:9000", "/api", "/queue/stats?size=20")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actual != "http://127.0.0.1:9000/api/queue/stats?size=20" {
+		t.Fatalf("unexpected proxy url: %s", actual)
 	}
 }

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -56,7 +56,7 @@ func TestShouldServeRegisteredAPIReverse(t *testing.T) {
 		{name: "queue stats", method: http.MethodGet, path: "/queue/stats", expect: true},
 		{name: "task search with query", method: http.MethodGet, path: "/pipeline/tasks/?size=20", expect: true},
 		{name: "config runtime", method: http.MethodGet, path: "/config/runtime", expect: true},
-		{name: "unsupported logger path", method: http.MethodPost, path: "/setting/logger", expect: false},
+		{name: "logger setting", method: http.MethodPost, path: "/setting/logger", expect: true},
 	}
 
 	for _, tc := range testCases {

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -45,3 +45,25 @@ func TestExecuteAgentReverseRequestUnknownPath(t *testing.T) {
 		t.Fatal("expected error body")
 	}
 }
+
+func TestShouldServeRegisteredAPIReverse(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method string
+		path   string
+		expect bool
+	}{
+		{name: "queue stats", method: http.MethodGet, path: "/queue/stats", expect: true},
+		{name: "task search with query", method: http.MethodGet, path: "/pipeline/tasks/?size=20", expect: true},
+		{name: "config runtime", method: http.MethodGet, path: "/config/runtime", expect: true},
+		{name: "unsupported logger path", method: http.MethodPost, path: "/setting/logger", expect: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := shouldServeRegisteredAPIReverse(tc.method, tc.path); actual != tc.expect {
+				t.Fatalf("unexpected match result: %v", actual)
+			}
+		})
+	}
+}

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestBuildAgentReverseChannelURL(t *testing.T) {
+	testCases := []struct {
+		name   string
+		server string
+		expect string
+	}{
+		{
+			name:   "http root",
+			server: "http://console.example.com",
+			expect: "ws://console.example.com/ws",
+		},
+		{
+			name:   "https base path",
+			server: "https://console.example.com/console",
+			expect: "wss://console.example.com/console/ws",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := buildAgentReverseChannelURL(tc.server)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.expect {
+				t.Fatalf("unexpected ws url, got %s want %s", actual, tc.expect)
+			}
+		})
+	}
+}
+
+func TestExecuteAgentReverseRequestUnknownPath(t *testing.T) {
+	status, body := executeAgentReverseRequest(http.MethodGet, "/not-found", nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("unexpected status: %d", status)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected error body")
+	}
+}

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	httprouter "infini.sh/framework/core/api/router"
+	framework_reverse "infini.sh/framework/core/api/websocket/reverse"
 )
 
 func TestBuildAgentReverseChannelURL(t *testing.T) {
@@ -40,7 +41,7 @@ func TestBuildAgentReverseChannelURL(t *testing.T) {
 }
 
 func TestExecuteAgentReverseRequestUnknownPath(t *testing.T) {
-	status, body := executeAgentReverseRequest(http.MethodGet, "/not-found", nil)
+	status, body := executeAgentReverseRequest(http.MethodGet, "/not-found", nil, framework_reverse.RequestMessage{})
 	if status != http.StatusNotFound {
 		t.Fatalf("unexpected status: %d", status)
 	}

--- a/plugin/api/reverse_channel_test.go
+++ b/plugin/api/reverse_channel_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"testing"
 
+	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
 	framework_reverse "infini.sh/framework/core/api/websocket/reverse"
 	"infini.sh/framework/core/global"
@@ -108,43 +109,35 @@ func TestReverseAPIRouterMatchesSpecialAndProtectedRoutes(t *testing.T) {
 }
 
 func TestExecuteAgentRegisteredAPIReverse(t *testing.T) {
-	oldResolver := agentReverseAPIProxyTargetResolver
-	oldClientFactory := agentReverseHTTPClientFactory
+	oldAPIConfig := global.Env().SystemConfig.APIConfig
 	t.Cleanup(func() {
-		agentReverseAPIProxyTargetResolver = oldResolver
-		agentReverseHTTPClientFactory = oldClientFactory
+		global.Env().SystemConfig.APIConfig = oldAPIConfig
 	})
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	global.Env().SystemConfig.APIConfig.Security.Enabled = true
+	global.Env().SystemConfig.APIConfig.Security.Username = "api-user"
+	global.Env().SystemConfig.APIConfig.Security.Password = "api-pass"
+
+	api.HandleAPIMethod(api.GET, "/queue/:id/stats", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 		user, password, ok := req.BasicAuth()
 		if !ok || user != "api-user" || password != "api-pass" {
 			t.Fatalf("unexpected basic auth: %v %s %s", ok, user, password)
 		}
-		if req.URL.Path != "/api/queue/stats" || req.URL.RawQuery != "size=20" {
-			t.Fatalf("unexpected proxied url: %s", req.URL.String())
+		if req.URL.Path != "/queue/test/stats" || req.URL.RawQuery != "size=20" {
+			t.Fatalf("unexpected request url: %s", req.URL.String())
+		}
+		if ps.ByName("id") != "test" {
+			t.Fatalf("unexpected route params: %#v", ps)
 		}
 		w.WriteHeader(http.StatusAccepted)
-		_, _ = w.Write([]byte("proxied"))
-	}))
-	defer server.Close()
+		_, _ = w.Write([]byte("served"))
+	})
 
-	agentReverseAPIProxyTargetResolver = func() (agentReverseProxyTarget, error) {
-		return agentReverseProxyTarget{
-			endpoint:      server.URL,
-			basePath:      "/api",
-			basicAuthUser: "api-user",
-			basicAuthPass: "api-pass",
-		}, nil
-	}
-	agentReverseHTTPClientFactory = func(agentReverseProxyTarget) (*http.Client, error) {
-		return server.Client(), nil
-	}
-
-	status, body := executeAgentRegisteredAPIReverse(http.MethodGet, "/queue/stats?size=20", nil, framework_reverse.RequestMessage{})
+	status, body := executeAgentRegisteredAPIReverse(http.MethodGet, "/queue/test/stats?size=20", nil, framework_reverse.RequestMessage{})
 	if status != http.StatusAccepted {
 		t.Fatalf("unexpected status: %d", status)
 	}
-	if string(body) != "proxied" {
+	if string(body) != "served" {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }


### PR DESCRIPTION
## Summary
- switch agent reverse-channel request and response handling to the shared framework websocket reverse protocol helpers
- raise the reverse websocket read limit to 8 MiB while keeping protected backend API requests on transparent local HTTP proxying instead of in-process API dispatch
- keep the current main-branch log handler names while refactoring reverse routing and tests onto the shared protocol package

## Dependencies
- agent#77
- framework#342
- framework#346
- framework#350

## Validation
- GOWORK=off go test -mod=mod -modfile=.copilot-test.mod ./plugin/api/... using a temporary local framework worktree stacking framework#342, framework#346, and framework#350
