### PR TITLE
feat: exchange managed tokens after register

### DIFF
--- a/config/generated.go
+++ b/config/generated.go
@@ -1,11 +1,11 @@
 package config
 
-const LastCommitLog = "N/A"
+const LastCommitLog = "c8f8114f965eeb3b1f21ce5e3b40283b7122e9b8"
 
-const BuildDate = "N/A"
+const BuildDate = "2026-05-24T13:36:37Z"
 
-const EOLDate = "N/A"
+const EOLDate  = "2126-12-31T10:10:10Z"
 
-const Version = "0.0.1-SNAPSHOT"
+const Version  = "1.0.0_SNAPSHOT"
 
-const BuildNumber = "001"
+const BuildNumber  = "001"

--- a/config/generated.go
+++ b/config/generated.go
@@ -1,11 +1,11 @@
 package config
 
-const LastCommitLog = "c8f8114f965eeb3b1f21ce5e3b40283b7122e9b8"
+const LastCommitLog = "N/A"
 
-const BuildDate = "2026-05-24T13:36:37Z"
+const BuildDate = "N/A"
 
-const EOLDate  = "2126-12-31T10:10:10Z"
+const EOLDate = "N/A"
 
-const Version  = "1.0.0_SNAPSHOT"
+const Version = "0.0.1-SNAPSHOT"
 
-const BuildNumber  = "001"
+const BuildNumber = "001"

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,8 +14,10 @@ Information about release notes of INFINI Agent is provided here.
 - feat: Log collection supports multiple paths and separate GC log directories. #75
 
 ### 🐛 Bug fix  
+- fix: secure managed Agent bootstrap, registration, token exchange, and config sync with scoped API tokens instead of the previous unauthenticated flow
 ### ✈️ Improvements  
 - chore: update security settings #70
+- chore: simplify managed startup by exchanging tokens through a post-register hook and using the web endpoint when the API listener is disabled
 - chore: git ignore .vscode and plugin/enterprise #69
 
 ## 1.31.0 (2026-04-18)

--- a/internal/managed/exchange.go
+++ b/internal/managed/exchange.go
@@ -1,0 +1,117 @@
+package managed
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/cihub/seelog"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/keystore"
+	"infini.sh/framework/core/model"
+	"infini.sh/framework/core/security"
+	"infini.sh/framework/core/util"
+	ucfg "infini.sh/framework/lib/go-ucfg"
+	"infini.sh/framework/modules/configs/client"
+	"infini.sh/framework/modules/security/access_token"
+)
+
+const (
+	tokenExchangeAPI       = "/instance/_exchange_token"
+	agentAPIAccessTokenKey = "AGENT_API_ACCESS_TOKEN"
+	managerAccessTokenKey  = "CONFIGS_MANAGER_ACCESS_TOKEN"
+)
+
+type tokenExchangeRequest struct {
+	InstanceID    string `json:"instance_id,omitempty"`
+	AgentAPIToken string `json:"agent_api_token,omitempty"`
+}
+
+type tokenExchangeResponse struct {
+	ManagerAPIToken string `json:"manager_api_token,omitempty"`
+}
+
+func getOrCreateAgentAPIToken(instance model.Instance) (string, error) {
+	if tokenBytes, err := keystore.GetValue(agentAPIAccessTokenKey); err == nil {
+		token := strings.TrimSpace(string(tokenBytes))
+		if token != "" {
+			return token, nil
+		}
+	}
+
+	user := &security.UserSessionInfo{
+		Provider: "managed_agent",
+		Login:    instance.ID,
+	}
+	user.SetUserID(instance.ID)
+	user.Set("instance_id", instance.ID)
+	user.Set("instance_name", instance.Name)
+	user.Set("endpoint", instance.Endpoint)
+
+	res, err := access_token.CreateAPIToken(user, fmt.Sprintf("%s agent api", instance.Name), "managed_agent_api", -1, nil)
+	if err != nil {
+		return "", err
+	}
+	token, ok := res["access_token"].(string)
+	if !ok || strings.TrimSpace(token) == "" {
+		return "", fmt.Errorf("failed to create agent api access token")
+	}
+	if err := keystore.SetValue(agentAPIAccessTokenKey, []byte(token)); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+func ExchangeTokens() error {
+	if !global.Env().SystemConfig.Configs.Managed || len(global.Env().SystemConfig.Configs.Servers) == 0 {
+		return nil
+	}
+	managerAPIToken := strings.TrimSpace(global.Env().SystemConfig.Configs.ManagerConfig.AccessToken.Get())
+	if managerAPIToken == "" {
+		return nil
+	}
+
+	instance := model.GetInstanceInfo()
+	agentAPIToken, err := getOrCreateAgentAPIToken(instance)
+	if err != nil {
+		return err
+	}
+
+	reqBody := tokenExchangeRequest{
+		InstanceID:    instance.ID,
+		AgentAPIToken: agentAPIToken,
+	}
+	req := util.Request{
+		Method:      util.Verb_POST,
+		Path:        tokenExchangeAPI,
+		ContentType: "application/json",
+		Body:        util.MustToJSONBytes(reqBody),
+	}
+	server, res, err := client.DoManagerRequest(&req)
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return fmt.Errorf("empty response from %s", server)
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("token exchange failed on %s, status: %d, body: %s", server, res.StatusCode, string(res.Body))
+	}
+
+	resp := tokenExchangeResponse{}
+	if err := util.FromJSONBytes(res.Body, &resp); err != nil {
+		return err
+	}
+	if strings.TrimSpace(resp.ManagerAPIToken) == "" {
+		return fmt.Errorf("manager api token is empty")
+	}
+	if err := keystore.SetValue(managerAccessTokenKey, []byte(resp.ManagerAPIToken)); err != nil {
+		return err
+	}
+	global.Env().SystemConfig.Configs.ManagerConfig.AccessToken = ucfg.SecretString(resp.ManagerAPIToken)
+	log.Infof("exchanged managed access token from %s", server)
+	return nil
+}
+
+func RegisterTokenExchangeCallback() {
+	client.AddPostRegisterHook(ExchangeTokens)
+}

--- a/internal/managed/module.go
+++ b/internal/managed/module.go
@@ -1,0 +1,27 @@
+package managed
+
+import "infini.sh/framework/core/module"
+
+const moduleName = "managed_agent_bootstrap"
+
+func init() {
+	module.RegisterModuleWithPriority(&ManagedModule{}, 100)
+}
+
+type ManagedModule struct{}
+
+func (m *ManagedModule) Name() string {
+	return moduleName
+}
+
+func (m *ManagedModule) Setup() {
+	RegisterTokenExchangeCallback()
+}
+
+func (m *ManagedModule) Start() error {
+	return nil
+}
+
+func (m *ManagedModule) Stop() error {
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/cihub/seelog"
 	public "infini.sh/agent/.public"
 	"infini.sh/agent/config"
+	_ "infini.sh/agent/internal/managed"
 	_ "infini.sh/agent/plugin"
 	api3 "infini.sh/agent/plugin/api"
 	"infini.sh/framework"


### PR DESCRIPTION
## Summary
- register managed token exchange through framework post-register hooks instead of wiring it directly in main startup
- exchange and persist the manager API token through authenticated manager requests while keeping a single CONFIGS_MANAGER_ACCESS_TOKEN source
- rely on the current instance endpoint selection and generated config defaults for managed startup
- update agent release notes for the managed bootstrap flow changes

## Testing
- GO111MODULE=off go test ./...
