### PR TITLE
fix: remove unnecessary IsAvailable gate from index_stats

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,6 +11,7 @@ Information about release notes of INFINI Agent is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- fix: remove unnecessary IsAvailable gate from index_stats #86
 ### ✈️ Improvements  
 
 ## 1.31.1 (2026-06-23)

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ title: "版本历史"
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- fix: index_stats 指标的采集不应该被 gate 在 IsAvailable(集群健康状态)后面 #86
 ### ✈️ Improvements  
 
 ## 1.31.1 (2026-06-23)

--- a/plugin/elastic/metric/index_stats/index_stats.go
+++ b/plugin/elastic/metric/index_stats/index_stats.go
@@ -96,20 +96,19 @@ func (p *IndexStats) Collect(k string, v *elastic.ElasticsearchMetadata) error {
 		var indexInfos *map[string]elastic.IndexInfo
 		shardInfos := map[string][]elastic.CatShardResponse{}
 
-		if v.IsAvailable() {
-			indexInfos, err = client.GetIndices("")
-			if err != nil {
-				log.Error(v.Config.Name, " get indices info error: ", err)
-			}
+		indexInfos, err = client.GetIndices("")
+		if err != nil {
+			log.Error(v.Config.Name, " get indices info error: ", err)
+		}
 
-			for _, item := range shards {
-				if _, ok := shardInfos[item.Index]; !ok {
-					shardInfos[item.Index] = []elastic.CatShardResponse{
-						item,
-					}
-				} else {
-					shardInfos[item.Index] = append(shardInfos[item.Index], item)
+		// Group the already-fetched cat/shards rows by index.
+		for _, item := range shards {
+			if _, ok := shardInfos[item.Index]; !ok {
+				shardInfos[item.Index] = []elastic.CatShardResponse{
+					item,
 				}
+			} else {
+				shardInfos[item.Index] = append(shardInfos[item.Index], item)
 			}
 		}
 


### PR DESCRIPTION
CatShards and CatIndices are read-only cat APIs that work regardless of
cluster health status. There is no reason to gate them behind
IsAvailable, which caused shard_info and index_info to be null in the
inspect flow where the flag is never set.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation